### PR TITLE
a11y: announce search errors to screen readers

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -96,7 +96,6 @@ test.describe("site search", () => {
     await expect(alert).toContainText("Search is temporarily unavailable", {
       timeout: 15000,
     });
-    await expect(alert).toHaveAttribute("aria-live", "assertive");
     await expect(
       dialog.getByText("Search is temporarily unavailable. Try again.")
     ).toBeVisible();
@@ -121,7 +120,6 @@ test.describe("site search", () => {
     await expect(alert).toContainText("Too many searches", {
       timeout: 15000,
     });
-    await expect(alert).toHaveAttribute("aria-live", "assertive");
     await expect(
       dialog.getByText("Too many searches. Wait a moment and try again.")
     ).toBeVisible();

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -92,10 +92,11 @@ test.describe("site search", () => {
     const dialog = page.getByRole("dialog");
     await page.getByPlaceholder("Search posts, talks, projects...").fill("ab");
 
-    const status = dialog.locator("[aria-live='polite']");
-    await expect(status).toHaveText("Search is temporarily unavailable", {
+    const alert = dialog.getByRole("alert");
+    await expect(alert).toContainText("Search is temporarily unavailable", {
       timeout: 15000,
     });
+    await expect(alert).toHaveAttribute("aria-live", "assertive");
     await expect(
       dialog.getByText("Search is temporarily unavailable. Try again.")
     ).toBeVisible();
@@ -116,10 +117,11 @@ test.describe("site search", () => {
     const dialog = page.getByRole("dialog");
     await page.getByPlaceholder("Search posts, talks, projects...").fill("ab");
 
-    const status = dialog.locator("[aria-live='polite']");
-    await expect(status).toHaveText("Too many searches", {
+    const alert = dialog.getByRole("alert");
+    await expect(alert).toContainText("Too many searches", {
       timeout: 15000,
     });
+    await expect(alert).toHaveAttribute("aria-live", "assertive");
     await expect(
       dialog.getByText("Too many searches. Wait a moment and try again.")
     ).toBeVisible();

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -76,4 +76,52 @@ test.describe("site search", () => {
     await page.keyboard.press("Escape");
     await expect(dialog).not.toBeVisible();
   });
+
+  test("announces a 503 search failure in the live region", async ({
+    page,
+  }) => {
+    await page.route("**/api/search*", async (route) => {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Search is temporarily unavailable." }),
+      });
+    });
+
+    await page.getByRole("button", { name: "Search site" }).click();
+    const dialog = page.getByRole("dialog");
+    await page.getByPlaceholder("Search posts, talks, projects...").fill("ab");
+
+    const status = dialog.locator("[aria-live='polite']");
+    await expect(status).toHaveText("Search is temporarily unavailable", {
+      timeout: 15000,
+    });
+    await expect(
+      dialog.getByText("Search is temporarily unavailable. Try again.")
+    ).toBeVisible();
+  });
+
+  test("announces a 429 search failure in the live region", async ({
+    page,
+  }) => {
+    await page.route("**/api/search*", async (route) => {
+      await route.fulfill({
+        status: 429,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Too many searches." }),
+      });
+    });
+
+    await page.getByRole("button", { name: "Search site" }).click();
+    const dialog = page.getByRole("dialog");
+    await page.getByPlaceholder("Search posts, talks, projects...").fill("ab");
+
+    const status = dialog.locator("[aria-live='polite']");
+    await expect(status).toHaveText("Too many searches", {
+      timeout: 15000,
+    });
+    await expect(
+      dialog.getByText("Too many searches. Wait a moment and try again.")
+    ).toBeVisible();
+  });
 });

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -333,14 +333,16 @@ const Search = () => {
             </kbd>
           </div>
 
-          {searchError ? (
-            <div className="flex min-h-[16rem] items-center justify-center text-center">
-              <div
-                className="space-y-2"
-                role="alert"
-                aria-live="assertive"
-                aria-atomic="true"
-              >
+          <div
+            role="alert"
+            className={
+              searchError
+                ? "flex min-h-[16rem] items-center justify-center text-center"
+                : "sr-only"
+            }
+          >
+            {searchError ? (
+              <div className="space-y-2">
                 <p className="text-lg text-destructive">
                   {SEARCH_ERROR_MESSAGE[searchError]}
                 </p>
@@ -348,8 +350,10 @@ const Search = () => {
                   Try searching again in a moment.
                 </p>
               </div>
-            </div>
-          ) : showResults ? (
+            ) : null}
+          </div>
+
+          {searchError ? null : showResults ? (
             <ul
               ref={resultsRef}
               className={`space-y-2 ${showSearching ? "opacity-60" : ""}`}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -254,10 +254,10 @@ const Search = () => {
   const showSearching = hasTypedEnough && (isSearching || isPendingSearch);
   const resultCountLabel =
     results.length === 1 ? "1 result found" : `${results.length} results found`;
-  const paneStatus = showSearching
-    ? "Searching…"
-    : searchError
-      ? SEARCH_ERROR_STATUS[searchError]
+  const paneStatus = searchError
+    ? SEARCH_ERROR_STATUS[searchError]
+    : showSearching
+      ? "Searching…"
       : showResults
         ? resultCountLabel
         : hasTypedEnough &&

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -321,7 +321,11 @@ const Search = () => {
           aria-busy={showSearching}
         >
           <div className="mb-4 flex h-6 items-baseline justify-between px-2 text-sm text-muted-foreground">
-            <span aria-live="polite" aria-atomic="true">
+            <span
+              aria-live="polite"
+              aria-atomic="true"
+              aria-hidden={searchError ? true : undefined}
+            >
               {paneStatus}
             </span>
             <kbd className="hidden rounded border border-secondary bg-muted px-1.5 py-0.5 font-sans text-xs sm:inline-block">
@@ -331,7 +335,12 @@ const Search = () => {
 
           {searchError ? (
             <div className="flex min-h-[16rem] items-center justify-center text-center">
-              <div className="space-y-2">
+              <div
+                className="space-y-2"
+                role="alert"
+                aria-live="assertive"
+                aria-atomic="true"
+              >
                 <p className="text-lg text-destructive">
                   {SEARCH_ERROR_MESSAGE[searchError]}
                 </p>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -9,13 +9,25 @@ import {
 
 const SEARCH_PLACEHOLDER = "Search posts, talks, projects...";
 
+type SearchErrorKind = "rate-limit" | "unavailable";
+
+const SEARCH_ERROR_MESSAGE: Record<SearchErrorKind, string> = {
+  "rate-limit": "Too many searches. Wait a moment and try again.",
+  unavailable: "Search is temporarily unavailable. Try again.",
+};
+
+const SEARCH_ERROR_STATUS: Record<SearchErrorKind, string> = {
+  "rate-limit": "Too many searches",
+  unavailable: "Search is temporarily unavailable",
+};
+
 const Search = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
-  const [searchError, setSearchError] = useState<string | null>(null);
+  const [searchError, setSearchError] = useState<SearchErrorKind | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -180,11 +192,7 @@ const Search = () => {
       setResults([]);
       setSelectedIndex(-1);
       const status = (error as { status?: number }).status;
-      setSearchError(
-        status === 429
-          ? "Too many searches. Wait a moment and try again."
-          : "Search is temporarily unavailable. Try again."
-      );
+      setSearchError(status === 429 ? "rate-limit" : "unavailable");
     } finally {
       if (!controller.signal.aborted) {
         setIsSearching(false);
@@ -248,13 +256,15 @@ const Search = () => {
     results.length === 1 ? "1 result found" : `${results.length} results found`;
   const paneStatus = showSearching
     ? "Searching…"
-    : showResults
-      ? resultCountLabel
-      : hasTypedEnough &&
-          trimmedQuery === submittedQuery &&
-          results.length === 0
-        ? "No results"
-        : "\u00a0";
+    : searchError
+      ? SEARCH_ERROR_STATUS[searchError]
+      : showResults
+        ? resultCountLabel
+        : hasTypedEnough &&
+            trimmedQuery === submittedQuery &&
+            results.length === 0
+          ? "No results"
+          : "\u00a0";
 
   return (
     <>
@@ -322,7 +332,9 @@ const Search = () => {
           {searchError ? (
             <div className="flex min-h-[16rem] items-center justify-center text-center">
               <div className="space-y-2">
-                <p className="text-lg text-destructive">{searchError}</p>
+                <p className="text-lg text-destructive">
+                  {SEARCH_ERROR_MESSAGE[searchError]}
+                </p>
                 <p className="text-sm text-muted-foreground">
                   Try searching again in a moment.
                 </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up from #1050. 429/503 copy lived in a separate visual block, so screen reader users heard **“No results”** (or nothing useful) instead of the failure.

Search errors now update a persistently mounted `role="alert"` (which already implies `aria-live="assertive"`). The container stays in the dialog even when idle so the announcement is a content change, not a newly created live region. The polite pane status still covers “Searching…”, result counts, and “No results”, and is `aria-hidden` while an error is showing so the same copy is not announced twice.

Closes #1053

## Test plan

- [ ] Cmd-K / `/` search still announces “Searching…”, result counts, and “No results” from the polite pane status
- [ ] 503: persistent `role="alert"` updates with “Search is temporarily unavailable. Try again.”
- [ ] 429: same alert updates with “Too many searches. Wait a moment and try again.”
- [ ] Playwright: `announces a 503 search failure in the live region` and `announces a 429 search failure in the live region`

[503 search error live region](https://cursor.com/agents/bc-79a10006-6450-41a1-839e-26a032ffee88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_error_503_live_region.png)
[429 search error live region](https://cursor.com/agents/bc-79a10006-6450-41a1-839e-26a032ffee88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_error_429_live_region.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79a10006-6450-41a1-839e-26a032ffee88?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79a10006-6450-41a1-839e-26a032ffee88&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search error handling for rate-limit and service-unavailable responses.
  * Added clear status messages and retry guidance when searches fail.
  * Ensured error states are announced accessibly and replace normal search results while active.

* **Tests**
  * Added coverage for search failures caused by HTTP 429 and 503 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->