### PR TITLE
a11y: combobox pattern for Cmd-K site search

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -120,6 +120,21 @@ test.describe("site search", () => {
     await expect(dialog).not.toBeVisible();
   });
 
+  test("one Escape closes the dialog after typing a query", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Search site" }).click();
+    const dialog = page.getByRole("dialog");
+    const input = page.getByPlaceholder("Search posts, talks, projects...");
+    await input.fill("Nick Taylor");
+    await expect(dialog.getByRole("option").first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible();
+  });
+
   test("announces a 503 search failure in the live region", async ({
     page,
   }) => {

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -35,7 +35,7 @@ test.describe("site search", () => {
     await expect(page.getByText(/\d+ results? found/)).toBeVisible({
       timeout: 15000,
     });
-    const results = dialog.getByRole("listitem");
+    const results = dialog.getByRole("option");
     await expect(results.first()).toBeVisible();
   });
 
@@ -55,17 +55,60 @@ test.describe("site search", () => {
     await input.fill("Nick Taylor");
 
     const dialog = page.getByRole("dialog");
-    const results = dialog.getByRole("listitem");
+    const results = dialog.getByRole("option");
     await expect(results.first()).toBeVisible({ timeout: 15000 });
 
     // The first result is already highlighted by default once results load,
     // so Enter alone should open it without pressing ArrowDown first.
-    const firstResultLink = results.first().getByRole("link");
-    const href = await firstResultLink.getAttribute("href");
+    const href = await results.first().getAttribute("href");
 
     await page.keyboard.press("Enter");
 
     await expect(page).toHaveURL(new RegExp(`${escapeRegExp(href!)}$`));
+  });
+
+  test("exposes results as a combobox listbox with aria-activedescendant", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Search site" }).click();
+    const input = page.getByRole("combobox", {
+      name: "Search posts, talks, and projects",
+    });
+    await expect(input).toHaveAttribute("aria-expanded", "false");
+
+    await input.fill("Nick Taylor");
+
+    const dialog = page.getByRole("dialog");
+    const results = dialog.getByRole("option");
+    await expect(results.first()).toBeVisible({ timeout: 15000 });
+
+    await expect(input).toHaveAttribute("aria-expanded", "true");
+    await expect(input).toHaveAttribute("aria-autocomplete", "list");
+    const listbox = dialog.getByRole("listbox", { name: "Search results" });
+    await expect(listbox).toBeVisible();
+    const listboxId = await listbox.getAttribute("id");
+    expect(listboxId).toBeTruthy();
+    await expect(input).toHaveAttribute("aria-controls", listboxId!);
+
+    const firstOptionId = await results.first().getAttribute("id");
+    expect(firstOptionId).toBeTruthy();
+    await expect(input).toHaveAttribute(
+      "aria-activedescendant",
+      firstOptionId!
+    );
+    await expect(results.first()).toHaveAttribute("aria-selected", "true");
+
+    const resultCount = await results.count();
+    if (resultCount > 1) {
+      await input.press("ArrowDown");
+      const secondOptionId = await results.nth(1).getAttribute("id");
+      await expect(input).toHaveAttribute(
+        "aria-activedescendant",
+        secondOptionId!
+      );
+      await expect(results.nth(1)).toHaveAttribute("aria-selected", "true");
+      await expect(results.first()).toHaveAttribute("aria-selected", "false");
+    }
   });
 
   test("Escape closes the dialog", async ({ page }) => {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
 import { Search as SearchIcon } from "lucide-react";
 import { searchSite, type SearchResult } from "../lib/search/searchSite";
 import {
@@ -22,6 +22,9 @@ const SEARCH_ERROR_STATUS: Record<SearchErrorKind, string> = {
 };
 
 const Search = () => {
+  const searchId = useId().replaceAll(":", "");
+  const resultsListId = `${searchId}-results`;
+  const optionId = (index: number) => `${searchId}-result-${index}`;
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
@@ -31,7 +34,7 @@ const Search = () => {
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const resultsRef = useRef<HTMLUListElement>(null);
+  const resultsRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
@@ -48,22 +51,12 @@ const Search = () => {
       } else if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         setIsOpen(true);
-      } else if (isOpen) {
-        if (e.key === "ArrowDown") {
-          e.preventDefault();
-          setSelectedIndex((prev) =>
-            prev < results.length - 1 ? prev + 1 : prev
-          );
-        } else if (e.key === "ArrowUp") {
-          e.preventDefault();
-          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev));
-        }
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, results]);
+  }, [isOpen]);
 
   useEffect(() => {
     const handleNavigation = () => {
@@ -246,12 +239,28 @@ const Search = () => {
     void performSearch(query);
   };
 
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (results.length === 0) {
+      return;
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((prev) => (prev < results.length - 1 ? prev + 1 : prev));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+    }
+  };
+
   const trimmedQuery = query.trim();
   const hasTypedEnough = trimmedQuery.length >= SEARCH_MIN_QUERY_CHARS;
   const isPendingSearch =
     hasTypedEnough && trimmedQuery !== submittedQuery && !isSearching;
   const showResults = results.length > 0 && hasTypedEnough;
   const showSearching = hasTypedEnough && (isSearching || isPendingSearch);
+  const activeOptionId =
+    showResults && selectedIndex >= 0 ? optionId(selectedIndex) : undefined;
   const resultCountLabel =
     results.length === 1 ? "1 result found" : `${results.length} results found`;
   const paneStatus = searchError
@@ -295,6 +304,11 @@ const Search = () => {
               ref={inputRef}
               type="search"
               name="q"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded={showResults}
+              aria-controls={showResults ? resultsListId : undefined}
+              aria-activedescendant={activeOptionId}
               maxLength={SEARCH_MAX_QUERY_CHARS}
               autoComplete="off"
               aria-label="Search posts, talks, and projects"
@@ -302,6 +316,7 @@ const Search = () => {
               className="w-full pl-10 pr-4 py-3 bg-secondary rounded-md focus:outline-none focus:ring-2 focus:ring-brand text-lg"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleInputKeyDown}
             />
           </form>
           <button
@@ -354,48 +369,58 @@ const Search = () => {
           </div>
 
           {searchError ? null : showResults ? (
-            <ul
+            /* Native select/option cannot host remote results, links, or
+               aria-activedescendant while focus stays in the combobox input. */
+            /* eslint-disable jsx-a11y/prefer-tag-over-role -- combobox listbox */
+            <div
               ref={resultsRef}
+              id={resultsListId}
+              role="listbox"
+              aria-label="Search results"
               className={`space-y-2 ${showSearching ? "opacity-60" : ""}`}
             >
               {results.map((result, index) => {
                 const isSelected = index === selectedIndex;
 
                 return (
-                  <li key={result.url}>
-                    <a
-                      href={result.url}
-                      aria-label={`${result.title} (${result.type})`}
-                      onMouseEnter={() => setSelectedIndex(index)}
-                      className={`block rounded-lg border p-4 outline-none transition-colors ${
-                        isSelected
-                          ? "border-brand/30 bg-secondary ring-1 ring-brand/20 dark:border-brand/30 dark:ring-brand/20"
-                          : "border-transparent hover:bg-secondary"
-                      }`}
-                    >
-                      <div className="flex items-start justify-between gap-4">
-                        <div className="min-w-0 flex-1">
-                          <h3
-                            className={`text-lg font-bold transition-colors ${
-                              isSelected ? "text-brand" : ""
-                            }`}
-                          >
-                            {result.title}
-                          </h3>
-                          <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-                            {result.excerpt}
-                          </p>
-                        </div>
-                        <span className="shrink-0 rounded-full border border-secondary bg-muted px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                          {result.type}
-                        </span>
+                  <a
+                    key={result.url}
+                    id={optionId(index)}
+                    href={result.url}
+                    role="option"
+                    aria-selected={isSelected}
+                    tabIndex={-1}
+                    aria-label={`${result.title} (${result.type})`}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    className={`block rounded-lg border p-4 outline-none transition-colors ${
+                      isSelected
+                        ? "border-brand/30 bg-secondary ring-1 ring-brand/20 dark:border-brand/30 dark:ring-brand/20"
+                        : "border-transparent hover:bg-secondary"
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0 flex-1">
+                        <h3
+                          className={`text-lg font-bold transition-colors ${
+                            isSelected ? "text-brand" : ""
+                          }`}
+                        >
+                          {result.title}
+                        </h3>
+                        <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                          {result.excerpt}
+                        </p>
                       </div>
-                    </a>
-                  </li>
+                      <span className="shrink-0 rounded-full border border-secondary bg-muted px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                        {result.type}
+                      </span>
+                    </div>
+                  </a>
                 );
               })}
-            </ul>
-          ) : showSearching ? (
+            </div>
+          ) : /* eslint-enable jsx-a11y/prefer-tag-over-role */
+          showSearching ? (
             <div className="flex min-h-[16rem] items-center justify-center text-muted-foreground">
               <p className="text-lg">Searching…</p>
             </div>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -240,6 +240,14 @@ const Search = () => {
   };
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      // type="search" would otherwise consume the first Escape to clear the
+      // field, leaving the dialog open until a second Escape.
+      e.preventDefault();
+      setIsOpen(false);
+      return;
+    }
+
     if (results.length === 0) {
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1052. Site search already highlighted results with arrow keys while focus stayed in the input; this wires the WAI-ARIA combobox pattern so screen readers hear “option 2 of 8” instead of requiring tabbing onto each link.

**Re: using a ShadCN/Radix combobox instead of this** — Combobox is the wrong widget here, so this keeps the existing native `<dialog>` and adds the missing roles.

- Current ShadCN Combobox is Base UI autocomplete-for-selecting-a-value (local `items`, popup, selected value). This UI is a command palette: remote Turso/Gemini results, navigation to a URL, rich result cards, already inside a native dialog.
- The old ShadCN Combobox (Popover + Command) has documented a11y gaps (`aria-expanded` / `aria-controls` / `aria-haspopup` missing on the trigger), so swapping to it would not actually fix this issue.
- ShadCN Command (`cmdk`) *is* the Cmd-K primitive and does implement combobox + `aria-activedescendant`. It would still need `shouldFilter={false}` plus the existing debounce/abort/error plumbing, and `CommandDialog` would replace the native `<dialog>` (viewport positioning, backdrop, Escape). This repo has `components.json` but no `src/components/ui/` and no cmdk/Radix/Base UI deps yet — that’s a larger stack decision than the missing ARIA.
- The gap from #1050 was small: keyboard highlight already existed. This adds `role="combobox"` / `aria-expanded` / `aria-controls` / `aria-activedescendant` on the input, `role="listbox"` on the results, and `role="option"` on each result (still an `<a href>` so mouse / middle-click keep working).

## Changes

- Search input is a combobox; results render as a listbox of options.
- Arrow Up/Down run on the input (combobox keyboard model) and update `aria-activedescendant`.
- Playwright covers the combobox attributes and that ArrowDown moves the active descendant.

## Verification

Locally (Astro dev + mocked `/api/search`, since 1Password isn’t available here):

- Collapsed combobox: `role="combobox"`, `aria-expanded="false"`, `aria-autocomplete="list"`
- After results: listbox + 3 options, `aria-activedescendant` on the first option
- ArrowDown moves `aria-activedescendant` / `aria-selected` and the visual highlight

[Empty search dialog with combobox input](https://cursor.com/agents/bc-934b12f7-0087-49a4-95e1-ec0a884df392/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_combobox_collapsed.png)
[First search result highlighted](https://cursor.com/agents/bc-934b12f7-0087-49a4-95e1-ec0a884df392/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_combobox_first_option.png)
[search_combobox_arrow_navigation.mp4](https://cursor.com/agents/bc-934b12f7-0087-49a4-95e1-ec0a884df392/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_combobox_arrow_navigation.mp4)

CI e2e will exercise the same flow against the Netlify deploy preview and the real search API.

## Test plan

- [x] Open search, confirm the input is a combobox with `aria-expanded="false"` until results load
- [x] Type a query, confirm results are options in a listbox and the first option is `aria-selected`
- [x] ArrowDown updates `aria-activedescendant` and the highlight
- [x] Enter still navigates to the highlighted result
- [x] Mouse click / middle-click on a result still works
- [x] Escape still closes the dialog


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-934b12f7-0087-49a4-95e1-ec0a884df392?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-934b12f7-0087-49a4-95e1-ec0a884df392&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved search semantics with an accessible combobox and listbox structure.
  * Added screen-reader announcements for search status and errors.
* **Usability**
  * Improved Arrow Up and Arrow Down navigation through search results.
  * Search results can be activated directly during keyboard navigation.
  * Simplified global keyboard shortcuts for opening search.
* **Tests**
  * Added coverage for accessibility attributes, result selection, and keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->