### PR TITLE
fix: remove duplicate "Searching…" text in search dialog

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useId, useRef, useState } from "react";
-import { Search as SearchIcon } from "lucide-react";
+import { Loader2, Search as SearchIcon } from "lucide-react";
 import {
   isSearchQueryTooLong,
   normalizeSearchQuery,
@@ -527,8 +527,11 @@ const Search = () => {
             </div>
           ) : /* eslint-enable jsx-a11y/prefer-tag-over-role */
           showSearching ? (
-            <div className="flex min-h-[16rem] items-center justify-center text-muted-foreground">
-              <p className="text-lg">Searching…</p>
+            <div
+              className="flex min-h-[16rem] items-center justify-center text-muted-foreground"
+              aria-hidden="true"
+            >
+              <Loader2 className="h-8 w-8 animate-spin opacity-50" />
             </div>
           ) : hasTypedEnough &&
             trimmedQuery === submittedQuery &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes duplicate "Searching…" text shown while a search is in progress.

The search dialog rendered the label in two places at once:
1. The status bar (`paneStatus`) — kept for the `aria-live` announcement
2. The main content area — replaced with a spinner

## Changes

- Keep a single "Searching…" label in the status bar for accessibility
- Show a loading spinner in the content area instead of repeating the text

## Test plan

- [x] Formatted and linted `Search.tsx`
- [ ] Open search, type a query, confirm only one "Searching…" appears while loading
- [ ] Confirm results and empty states still render correctly after search completes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ceff226-4e32-43db-bd44-18544d8672ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ceff226-4e32-43db-bd44-18544d8672ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Replaced the “Searching…” text with an animated loading spinner while search results are being fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->