### PR TITLE
fix(a11y): improve color contrast on series nav and speaker bio (P1)

### DIFF
--- a/src/components/SeriesNavigation.astro
+++ b/src/components/SeriesNavigation.astro
@@ -117,7 +117,7 @@ const getStaticIndex = (post: CollectionEntry<"blog">) =>
               ) : (
                 <a
                   href={`/blog/${post.id}`}
-                  class="block text-sm leading-tight text-muted-foreground no-underline hover:text-brand hover:underline focus-visible:underline focus-visible:outline-none"
+                  class="block text-sm leading-tight text-brand-soft-foreground no-underline hover:text-brand hover:underline focus-visible:underline focus-visible:outline-none"
                 >
                   {truncate(post.data.title, 80)}
                 </a>
@@ -132,8 +132,8 @@ const getStaticIndex = (post: CollectionEntry<"blog">) =>
         middleHiddenBefore.length > 0 && (
           <li>
             <details class="group/nested">
-              <summary class="flex items-center gap-2 cursor-pointer list-none text-sm text-muted-foreground hover:text-brand focus-visible:outline-none focus-visible:underline ornament-none">
-                <span class="grid h-6 w-6 place-items-center tracking-tight text-muted-foreground/70">
+              <summary class="flex items-center gap-2 cursor-pointer list-none text-sm text-brand-soft-foreground hover:text-brand focus-visible:outline-none focus-visible:underline ornament-none">
+                <span class="grid h-6 w-6 place-items-center tracking-tight text-brand-soft-foreground">
                   ···
                 </span>
                 <span class="group-open/nested:hidden">
@@ -150,7 +150,7 @@ const getStaticIndex = (post: CollectionEntry<"blog">) =>
                     <div class="min-w-0 flex-1 pt-0.5">
                       <a
                         href={`/blog/${post.id}`}
-                        class="block text-sm leading-tight text-muted-foreground hover:text-brand hover:underline focus:text-brand focus:underline"
+                        class="block text-sm leading-tight text-brand-soft-foreground hover:text-brand hover:underline focus:text-brand focus:underline"
                       >
                         {truncate(post.data.title, 80)}
                       </a>
@@ -184,8 +184,8 @@ const getStaticIndex = (post: CollectionEntry<"blog">) =>
         middleHiddenAfter.length > 0 && (
           <li>
             <details class="group/nested">
-              <summary class="flex items-center gap-2 cursor-pointer list-none text-sm text-muted-foreground hover:text-brand focus-visible:outline-none focus-visible:underline ornament-none">
-                <span class="grid h-6 w-6 place-items-center tracking-tight text-muted-foreground/70">
+              <summary class="flex items-center gap-2 cursor-pointer list-none text-sm text-brand-soft-foreground hover:text-brand focus-visible:outline-none focus-visible:underline ornament-none">
+                <span class="grid h-6 w-6 place-items-center tracking-tight text-brand-soft-foreground">
                   ···
                 </span>
                 <span class="group-open/nested:hidden">
@@ -202,7 +202,7 @@ const getStaticIndex = (post: CollectionEntry<"blog">) =>
                     <div class="min-w-0 flex-1 pt-0.5">
                       <a
                         href={`/blog/${post.id}`}
-                        class="block text-sm leading-tight text-muted-foreground hover:text-brand hover:underline focus:text-brand focus:underline"
+                        class="block text-sm leading-tight text-brand-soft-foreground hover:text-brand hover:underline focus:text-brand focus:underline"
                       >
                         {truncate(post.data.title, 80)}
                       </a>
@@ -237,7 +237,7 @@ const getStaticIndex = (post: CollectionEntry<"blog">) =>
               ) : (
                 <a
                   href={`/blog/${post.id}`}
-                        class="block text-sm leading-tight text-muted-foreground no-underline hover:text-brand hover:underline focus:text-brand focus:underline focus-visible:outline-none"
+                        class="block text-sm leading-tight text-brand-soft-foreground no-underline hover:text-brand hover:underline focus:text-brand focus:underline focus-visible:outline-none"
                 >
                   {truncate(post.data.title, 80)}
                 </a>

--- a/src/pages/speaking.astro
+++ b/src/pages/speaking.astro
@@ -202,7 +202,7 @@ const speakerBioHtml = markdownFilter(speakerBioMarkdown);
           />
         </div>
         <div
-          class="pr-10 text-lg leading-relaxed text-muted-foreground [&_a]:text-brand [&_a]:font-semibold [&_a:hover]:underline [&_a:focus]:underline [&_a:focus]:outline-none"
+          class="pr-10 text-lg leading-relaxed text-foreground [&_em]:text-foreground [&_a]:text-brand [&_a]:font-semibold [&_a:hover]:underline [&_a:focus]:underline [&_a:focus]:outline-none"
           set:html={speakerBioHtml}
         />
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes P1 accessibility findings from the Aug 2026 audit ([#1063](https://github.com/nickytonline/nickytdotco/issues/1063)).

## Changes

- **Series navigation:** Replace `text-muted-foreground` / `text-muted-foreground/70` with `text-brand-soft-foreground` on the brand-soft panel so series links and collapse affordances meet WCAG AA contrast.
- **Speaker bio:** Use `text-foreground` (with `[&_em]:text-foreground`) in the `/speaking` bio block so inline links and emphasis pass axe `color-contrast`.

## Verification

- axe flagged `color-contrast` on the sampled blog post and `/speaking` before this change; both areas now use higher-contrast semantic tokens.
- `vp fmt --check` passes on touched files.

## Before / after

### Series navigation (blog post with series)

[Series navigation before — low-contrast muted links on brand-soft background](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp1_series_nav_before.png)
[Series navigation after — brand-soft-foreground links on brand-soft background](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp1_series_nav_after.png)

### Speaker bio (`/speaking`)

[Speaker bio before — muted body text with low-contrast link and emphasis](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp1_speaking_bio_before.png)
[Speaker bio after — foreground body text with improved contrast](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp1_speaking_bio_after.png)

## Sub-issues closed by this PR

- #1064 — Series nav contrast
- #1065 — Speaker bio contrast

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04577-0b90-739e-adef-e0b8c9dcafaf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved contrast and consistency for series navigation links, expandable summaries, and ellipsis markers.
  * Updated speaker biographies for clearer text visibility, including emphasized text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->