### PR TITLE
fix(a11y): correct heading hierarchy across site chrome (P2)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -23,14 +23,14 @@ const isCurrent = (href: string) =>
     class="flex flex-col items-center gap-6 md:flex-row md:items-start md:justify-between"
   >
     <div class="flex w-full flex-col items-center gap-4 md:w-auto md:items-start md:gap-6">
-      <h1
-        class="font-heading md:text-6xl lg:text-8xl font-medium"
+      <p
+        class="font-heading md:text-6xl lg:text-8xl font-medium m-0"
         transition:name="header-logo"
       >
         <a href="/" class="text-current no-underline"
           >nickyt<span class="text-brand">.</span>co</a
         >
-      </h1>
+      </p>
       <nav
         aria-label="main navigation"
         class="mt-2 hidden text-xl md:block md:text-2xl lg:text-3xl"

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -33,7 +33,7 @@ const { project } = Astro.props;
     <div class="flex items-start justify-between mb-2">
       <div class="flex flex-col">
         <span class="text-xs text-muted-foreground mb-1">{project.owner}/</span>
-        <h3
+        <h2
           class="text-xl font-bold text-foreground group-hover:text-brand group-focus-within:text-brand transition-colors"
         >
           <a
@@ -44,7 +44,7 @@ const { project } = Astro.props;
           >
             {project.name}
           </a>
-        </h3>
+        </h2>
       </div>
       <div
         class="flex items-center gap-1 text-muted-foreground bg-muted/50 px-2 py-1 rounded text-xs"

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -230,7 +230,7 @@ const socialBrandClasses: Record<string, string> = {
         </div>
 
         <div class="flex-1 min-w-0">
-          <h3 class="text-lg font-semibold text-foreground">{social.name}</h3>
+          <h2 class="text-lg font-semibold text-foreground">{social.name}</h2>
           <p class="text-sm text-muted-foreground mt-1">{social.description}</p>
         </div>
       </a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes P2 accessibility findings from the Aug 2026 audit ([#1063](https://github.com/nickytonline/nickytdotco/issues/1063)).

## Changes

- **Projects:** Project card titles `h3` → `h2` so headings do not skip from page `h1`.
- **Socials:** Social card titles `h3` → `h2`.
- **Header:** Site logo wrapper `h1` → `p` so each page has a single document `h1` in main content (verified: `/about` now has 1 `h1` instead of 2).

## Verification

- axe flagged `heading-order` on `/projects` and `/socials` before this change.
- Playwright check on built `/about/`: `h1` count is now **1** (`About` only).

## Before / after

Visual appearance is unchanged; these are semantic fixes. Screenshots show the same regions audited.

### Projects cards

[Projects page before heading fix](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp2_projects_headings_before.png)
[Projects page after heading fix](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp2_projects_headings_after.png)

### Socials cards

[Socials page before heading fix](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp2_socials_headings_before.png)
[Socials page after heading fix](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp2_socials_headings_after.png)

### Single page h1 (`/about` header + title)

[About page before — logo and page title both h1](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp2_about_duplicate_h1_before.png)
[About page after — only page title is h1](https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fp2_about_duplicate_h1_after.png)

## Sub-issues closed by this PR

- #1066 — Projects heading order
- #1067 — Socials heading order
- #1068 — Duplicate document h1

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04577-0b90-739e-adef-e0b8c9dcafaf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04577-0b90-739e-adef-e0b8c9dcafaf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved heading hierarchy across the site for clearer page structure and better screen reader navigation.
  * Updated project and social link headings to use appropriate heading levels.
  * Changed the site logo’s semantic element while preserving its appearance and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->