### PR TITLE
fix: hide previous search results while a new query is in flight

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -196,6 +196,33 @@ test.describe("site search", () => {
   test("hides previous results while a new search is in flight", async ({
     page,
   }) => {
+    const fulfillSearch = (query: string, title: string) => ({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        query,
+        results: [
+          {
+            url: `/blog/${query.replaceAll(" ", "-").toLowerCase()}`,
+            title,
+            excerpt: `Excerpt for ${title}`,
+            type: "Post",
+          },
+        ],
+      }),
+    });
+
+    await page.route("**/api/search*", async (route) => {
+      const url = new URL(route.request().url());
+      const q = url.searchParams.get("q") ?? "";
+      if (/rust/i.test(q)) {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        await route.fulfill(fulfillSearch(q, "Cool Rust and WebAssembly"));
+        return;
+      }
+      await route.fulfill(fulfillSearch(q, "Nick Taylor"));
+    });
+
     await page.getByRole("button", { name: "Search site" }).click();
     const dialog = page.getByRole("dialog");
     const input = page.getByPlaceholder("Search posts, talks, projects...");
@@ -203,11 +230,7 @@ test.describe("site search", () => {
 
     const results = dialog.getByRole("option");
     await expect(results.first()).toBeVisible({ timeout: 15000 });
-
-    await page.route("**/api/search*", async (route) => {
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      await route.continue();
-    });
+    await expect(results.first()).toContainText("Nick Taylor");
 
     await input.fill("Rust");
 
@@ -215,6 +238,7 @@ test.describe("site search", () => {
     await expect(results).toHaveCount(0);
 
     await expect(results.first()).toBeVisible({ timeout: 15000 });
+    await expect(results.first()).toContainText("Cool Rust and WebAssembly");
     await expect(dialog.getByText("Searching…")).toHaveCount(0);
   });
 });

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -192,4 +192,29 @@ test.describe("site search", () => {
       dialog.getByText("Too many searches. Wait a moment and try again.")
     ).toBeVisible();
   });
+
+  test("hides previous results while a new search is in flight", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Search site" }).click();
+    const dialog = page.getByRole("dialog");
+    const input = page.getByPlaceholder("Search posts, talks, projects...");
+    await input.fill("Nick Taylor");
+
+    const results = dialog.getByRole("option");
+    await expect(results.first()).toBeVisible({ timeout: 15000 });
+
+    await page.route("**/api/search*", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await route.continue();
+    });
+
+    await input.fill("Rust");
+
+    await expect(dialog.getByText("Searching…")).toBeVisible();
+    await expect(results).toHaveCount(0);
+
+    await expect(results.first()).toBeVisible({ timeout: 15000 });
+    await expect(dialog.getByText("Searching…")).toHaveCount(0);
+  });
 });

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -194,6 +194,8 @@ const Search = () => {
       setIsSearching(true);
       setSearchError(null);
       setSubmittedQuery(trimmed);
+      setResults([]);
+      setSelectedIndex(-1);
 
       try {
         const response = await searchSite(
@@ -330,6 +332,7 @@ const Search = () => {
     if (
       selectedIndex >= 0 &&
       results.length > 0 &&
+      !isSearching &&
       normalizedInput === submittedQuery
     ) {
       openSelectedResult();
@@ -347,7 +350,11 @@ const Search = () => {
       return;
     }
 
-    if (results.length === 0) {
+    if (
+      results.length === 0 ||
+      isSearching ||
+      query.trim() !== submittedQuery
+    ) {
       return;
     }
 
@@ -364,8 +371,9 @@ const Search = () => {
   const hasTypedEnough = trimmedQuery.length >= SEARCH_MIN_QUERY_CHARS;
   const isPendingSearch =
     hasTypedEnough && trimmedQuery !== submittedQuery && !isSearching;
-  const showResults = results.length > 0 && hasTypedEnough;
   const showSearching = hasTypedEnough && (isSearching || isPendingSearch);
+  // Drop stale hits as soon as Searching… is shown for a new query.
+  const showResults = results.length > 0 && hasTypedEnough && !showSearching;
   const activeOptionId =
     showResults && selectedIndex >= 0 ? optionId(selectedIndex) : undefined;
   const resultCountLabel =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a search already has results and you type a new query, the dialog showed **Searching…** while the previous hits stayed on screen until the next response arrived.

The results list now hides as soon as Searching… appears (debounce or in-flight), and the loading spinner takes its place. Starting a new search also clears the stale result state so Enter cannot open an old hit for the new query.

Rebased onto latest `main` (includes `#1080` upcoming pill and `#1081` CDN cache expiry).

## Changes

- Hide the result list whenever `showSearching` is true
- Clear results when a search request starts
- Ignore arrow-key navigation and Enter-to-open while a new search is pending or in flight
- Add e2e coverage that mocks a delayed second search and asserts previous results are gone while Searching… is shown

## Test plan

- [x] Formatted and linted `Search.tsx` and `e2e/search.spec.ts`
- [x] Rebased onto latest `main`
- [x] Playwright e2e `hides previous results while a new search is in flight` passed against the deploy preview
- [x] Manual check on the preview: search `rust`, type `rustr`, previous cards disappear as soon as Searching… shows (spinner only)
- [x] New results still appear after the request finishes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7de53a5-df5a-4b0f-9d35-4c292602d016?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7de53a5-df5a-4b0f-9d35-4c292602d016&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

