### PR TITLE
feat: add upcoming pill to future video pages

### DIFF
--- a/e2e/watch-and-videos.spec.ts
+++ b/e2e/watch-and-videos.spec.ts
@@ -77,5 +77,28 @@ test.describe("video archives", () => {
       );
 
     expect(videoStructuredDataCount).toBe(1);
+    await expect(page.getByText("Upcoming livestream")).toHaveCount(0);
+  });
+
+  test("upcoming stream video pages show an upcoming pill", async ({
+    page,
+  }) => {
+    await page.goto("/watch");
+
+    const upcomingHeading = page.getByRole("heading", {
+      name: "Upcoming Live Streams",
+    });
+    if (!(await upcomingHeading.count())) {
+      test.skip(true, "no upcoming streams scheduled");
+    }
+
+    const section = upcomingHeading.locator("xpath=ancestor::section");
+    const videoLink = section.locator('a[href^="/videos/"]').first();
+    if ((await videoLink.count()) === 0) {
+      test.skip(true, "upcoming streams have no on-site video pages");
+    }
+
+    await videoLink.click();
+    await expect(page.getByText("Upcoming livestream")).toBeVisible();
   });
 });

--- a/src/pages/videos/[slug].astro
+++ b/src/pages/videos/[slug].astro
@@ -6,6 +6,7 @@ import { dateFilter } from "../../utils/filters";
 import { site } from "../../data/site";
 import { markdownFilter } from "../../utils/markdown";
 import YouTubeEmbed from "../../components/embeds/YouTubeEmbed.astro";
+import UpcomingBadge from "../../components/UpcomingBadge.astro";
 import {
   extractYouTubeVideoId,
   slugifyVideo,
@@ -22,6 +23,7 @@ export async function getStaticPaths() {
 const { stream } = Astro.props;
 const { title, date, description, guestName, guestTitle, youtubeStreamLink } =
   stream.data;
+const isUpcoming = new Date(date).getTime() > Date.now();
 const descriptionHtml = markdownFilter(description);
 
 const videoId = extractYouTubeVideoId(youtubeStreamLink);
@@ -144,10 +146,13 @@ if (stream.data.website)
       >
         {title}
       </h1>
-      <div class="text-lg text-muted-foreground mt-2">
+      <div
+        class="flex flex-wrap items-center gap-2 leading-none text-lg text-muted-foreground mt-2"
+      >
         <time datetime={new Date(date).toISOString()} class="italic">
           {dateFilter(new Date(date))}
         </time>
+        {isUpcoming && <UpcomingBadge label="Upcoming livestream" />}
       </div>
       <p class="text-base text-muted-foreground mt-1">
         with <span class="font-semibold">{guestName}</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Talk pages already show an **Upcoming talk** pill. Stream video pages never did, even when the stream is still in the future — git history has no upcoming badge on `/videos/[slug]`.

This adds the shared `UpcomingBadge` next to the date on future video pages (`Upcoming livestream`), using the stream date at build time. Past archive pages stay unchanged.

Livestream **cards** on the home/watch listings used to have this badge and it was removed in `ad63645e` to avoid duplicating the category pill. This change is only the video detail page, which had no pill at all.

## Screenshots

Upcoming video page (pill present):

[Upcoming livestream pill on How People AI Vol. 2](https://cursor.com/agents/bc-bf16c479-a3cb-446e-b20f-287641bcf570/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fupcoming_video_page_pill.webp)

Past video page (no pill):

[Past How People AI Vol. 1 video page without an upcoming pill](https://cursor.com/agents/bc-bf16c479-a3cb-446e-b20f-287641bcf570/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpast_video_page_no_pill.webp)

## Test plan
- Open an upcoming stream from `/watch` and confirm the video page shows the **Upcoming livestream** pill next to the date.
- Open a past video from `/videos` and confirm the pill is not present.
- Compare with an upcoming talk page (`Upcoming talk` pill) for visual consistency.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf16c479-a3cb-446e-b20f-287641bcf570?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf16c479-a3cb-446e-b20f-287641bcf570&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upcoming livestreams now display an “Upcoming livestream” badge alongside their scheduled date.
  - Added coverage to verify upcoming and past video pages show the appropriate status.

- **Bug Fixes**
  - Improved video detail pages so past videos no longer display the upcoming livestream indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->