### PR TITLE
fix: expire watch and talks CDN cache at the next upcoming event

### DIFF
--- a/src/components/StreamSchedule.astro
+++ b/src/components/StreamSchedule.astro
@@ -4,6 +4,7 @@ import { getHeadingId, getLocalizedDate } from "../utils/schedule-utils";
 import { getYouTubeId } from "../utils/youtube-utils";
 import { slugifyVideo } from "../utils/video-utils";
 import LiveStreamCard from "./LiveStreamCard.astro";
+import { isEventUpcoming } from "../utils/cdn-cache";
 
 const TWITCH_STREAM_URL = "https://www.twitch.tv/nickytonline";
 
@@ -73,7 +74,7 @@ const fullSchedule: Array<StreamGuestInfo> = schedule.sort((a, b) => {
       const guestInfo = noGuest
         ? ""
         : `Guest: ${guestName}${guestTitle ? `, ${guestTitle}` : ""}`;
-      const upcoming = new Date(date).getTime() > now;
+      const upcoming = isEventUpcoming(new Date(date), now);
 
       const eventName =
         guestName === "2Full2Stack"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,11 @@ import { fetchPastGuestsWithYouTube } from "../content/_loaders/stream-schedule"
 import TalkCard from "../components/TalkCard.astro";
 import GuideCard from "../components/GuideCard.astro";
 import ProjectCard from "../components/ProjectCard.astro";
+import {
+  isEventUpcoming,
+  setCdnCacheHeaders,
+  soonestExpiryTimestamp,
+} from "../utils/cdn-cache";
 
 const allPosts = await getCollection("blog", ({ data }) => {
   return import.meta.env.PROD ? data.draft !== true : true;
@@ -43,7 +48,9 @@ const featuredTalkIds = new Set(featuredTalks.map((t) => t.id));
 
 // Upcoming talks: all future events, not a capped subset.
 const upcomingTalks = allTalks.filter(
-  (t) => t.data.upcoming === true && (t.data.endDate ?? t.data.date) >= now,
+  (t) =>
+    t.data.upcoming === true &&
+    isEventUpcoming(t.data.endDate ?? t.data.date, now.getTime()),
 );
 const recentTalks = allTalks
   .filter(
@@ -98,8 +105,8 @@ if (scheduleResult.error) {
   errorMessage = "Error fetching stream schedule.";
 } else {
   schedule = scheduleResult.entries?.map((entry) => entry.data) ?? [];
-  upcomingStreams = schedule.filter(
-    (stream) => new Date(stream.date).getTime() > now.getTime(),
+  upcomingStreams = schedule.filter((stream) =>
+    isEventUpcoming(new Date(stream.date), now.getTime()),
   );
 }
 
@@ -145,25 +152,18 @@ const latestContent = [
 const { timezone: rawTimezone } = Astro.locals.netlify.context.geo;
 const timezone = rawTimezone || "UTC";
 
-// Expire when the next event starts so it drops off Upcoming, capped at 1 day
-// so newly scheduled Turso streams still appear without a deploy.
-const CDN_CACHE_MAX_SECONDS = 86_400;
-const secondsUntilNextEvent = hasUpcomingEvents
-  ? Math.max(
-      0,
-      Math.floor((upcomingEvents[0].timestamp - now.getTime()) / 1000),
-    )
-  : CDN_CACHE_MAX_SECONDS;
-const cdnMaxAge = Math.min(CDN_CACHE_MAX_SECONDS, secondsUntilNextEvent);
-
 if (!errorMessage) {
-  Astro.response.headers.set(
-    "Cache-Control",
-    "public, max-age=0, must-revalidate",
-  );
-  Astro.response.headers.set(
-    "Netlify-CDN-Cache-Control",
-    `public, max-age=${cdnMaxAge}, must-revalidate`,
+  setCdnCacheHeaders(
+    Astro.response.headers,
+    soonestExpiryTimestamp(
+      upcomingEvents.map((event) =>
+        event.kind === "talk"
+          ? (event.item.data.endDate ?? event.item.data.date)
+          : new Date(event.item.date),
+      ),
+      now.getTime(),
+    ),
+    now.getTime(),
   );
   Astro.response.headers.set("timezone", timezone);
   Astro.response.headers.set("Netlify-Vary", "header=Accept-Language|timezone");

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -6,9 +6,26 @@ import SectionHeader from "../components/SectionHeader.astro";
 import Breadcrumb from "../components/Breadcrumb.astro";
 import { dateFilter } from "../utils/filters";
 import { getYouTubeId } from "../utils/youtube-utils";
-export const prerender = true;
+import {
+  isEventUpcoming,
+  setCdnCacheHeaders,
+  soonestExpiryTimestamp,
+} from "../utils/cdn-cache";
 
+export const prerender = false;
+
+const now = Date.now();
 const talks = await getCollection("talks");
+setCdnCacheHeaders(
+  Astro.response.headers,
+  soonestExpiryTimestamp(
+    talks
+      .filter((talk) => talk.data.upcoming === true)
+      .map((talk) => talk.data.endDate ?? talk.data.date),
+    now,
+  ),
+  now,
+);
 const sortedTalks = talks.sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime(),
 );
@@ -94,7 +111,9 @@ const years = Object.keys(talksByYear)
             {talksByYear[year].map((talk) => {
               const slug = talk.id;
               const video = talk.data.video;
-              const isUpcoming = talk.data.upcoming === true;
+              const isUpcoming =
+                talk.data.upcoming === true &&
+                isEventUpcoming(talk.data.endDate ?? talk.data.date, now);
               let thumbnailUrl: string | undefined;
               if (talk.data.cover_image) {
                 thumbnailUrl = talk.data.cover_image;

--- a/src/pages/videos/index.astro
+++ b/src/pages/videos/index.astro
@@ -9,11 +9,27 @@ import {
   extractYouTubeVideoId,
   slugifyVideo,
 } from "../../utils/video-utils";
+import {
+  isEventUpcoming,
+  setCdnCacheHeaders,
+  soonestExpiryTimestamp,
+} from "../../utils/cdn-cache";
+
+export const prerender = false;
 
 const result = await getLiveCollection("streamVideos");
-const now = new Date();
-const entries = (result.entries ?? []).filter(
-  (e) => new Date(e.data.date) < now
+const now = Date.now();
+const allEntries = result.entries ?? [];
+setCdnCacheHeaders(
+  Astro.response.headers,
+  soonestExpiryTimestamp(
+    allEntries.map((entry) => new Date(entry.data.date)),
+    now,
+  ),
+  now,
+);
+const entries = allEntries.filter(
+  (e) => !isEventUpcoming(new Date(e.data.date), now),
 );
 const sortedStreams = [...entries].sort(
   (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime()

--- a/src/pages/watch.astro
+++ b/src/pages/watch.astro
@@ -9,6 +9,13 @@ import { getLiveCollection } from "astro:content";
 import type { StreamVideoInfo } from "@/content/_loaders/stream-videos";
 import { getYouTubeId } from "@/utils/youtube-utils";
 import { slugifyVideo } from "@/utils/video-utils";
+import {
+  isEventUpcoming,
+  setCdnCacheHeaders,
+  soonestExpiryTimestamp,
+} from "@/utils/cdn-cache";
+
+const now = Date.now();
 
 const locale =
   Astro.request.headers.get("Accept-Language")?.split(",")[0] ||
@@ -27,14 +34,16 @@ if (scheduleResult.error) {
   schedule = scheduleResult.entries?.map((entry) => entry.data) ?? [];
 }
 
+schedule = schedule.filter((stream) =>
+  isEventUpcoming(new Date(stream.date), now),
+);
+
 let latestVideos: StreamVideoInfo[] = [];
 const streamVideosResult = await getLiveCollection("streamVideos");
 
 if (streamVideosResult.error) {
   console.error("Error fetching stream videos:", streamVideosResult.error);
 } else {
-  const now = Date.now();
-
   const pastVideos =
     streamVideosResult.entries
       ?.map((entry) => entry.data)
@@ -59,14 +68,16 @@ if (streamVideosResult.error) {
 const { timezone: rawTimezone } = Astro.locals.netlify.context.geo;
 const timezone = rawTimezone || "UTC";
 
-Astro.response.headers.set(
-  "Cache-Control",
-  "public, max-age=0, must-revalidate",
-);
-Astro.response.headers.set(
-  "Netlify-CDN-Cache-Control",
-  "public, max-age=259200, must-revalidate",
-);
+if (!errorMessage) {
+  setCdnCacheHeaders(
+    Astro.response.headers,
+    soonestExpiryTimestamp(
+      schedule.map((stream) => new Date(stream.date)),
+      now,
+    ),
+    now,
+  );
+}
 Astro.response.headers.set("timezone", timezone);
 Astro.response.headers.set("Netlify-Vary", "header=Accept-Language|timezone");
 

--- a/src/utils/cdn-cache.test.ts
+++ b/src/utils/cdn-cache.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  CDN_CACHE_MAX_SECONDS,
+  cdnMaxAgeSeconds,
+  eventExpiryTimestamp,
+  isEventUpcoming,
+  isUtcMidnight,
+  soonestExpiryTimestamp,
+} from "./cdn-cache.ts";
+
+describe("eventExpiryTimestamp", () => {
+  it("keeps timed events at that instant, including non-UTC offsets", () => {
+    const date = new Date("2026-09-25T15:45:00-03:00");
+    expect(isUtcMidnight(date)).toBe(false);
+    expect(eventExpiryTimestamp(date)).toBe(date.getTime());
+  });
+
+  it("treats UTC midnight as date-only and expires at the next UTC midnight", () => {
+    const date = new Date("2026-09-15T00:00:00.000Z");
+    expect(isUtcMidnight(date)).toBe(true);
+    expect(eventExpiryTimestamp(date)).toBe(
+      Date.parse("2026-09-16T00:00:00.000Z")
+    );
+  });
+});
+
+describe("isEventUpcoming", () => {
+  it("keeps a date-only event upcoming through that UTC day", () => {
+    const date = new Date("2026-09-15T00:00:00.000Z");
+    expect(isEventUpcoming(date, Date.parse("2026-09-15T18:00:00.000Z"))).toBe(
+      true
+    );
+    expect(isEventUpcoming(date, Date.parse("2026-09-16T00:00:00.000Z"))).toBe(
+      false
+    );
+  });
+});
+
+describe("cdnMaxAgeSeconds", () => {
+  it("caps at one day when the next event is further out", () => {
+    const now = Date.parse("2026-01-01T00:00:00.000Z");
+    const next = Date.parse("2026-01-10T00:00:00.000Z");
+    expect(cdnMaxAgeSeconds(next, now)).toBe(CDN_CACHE_MAX_SECONDS);
+  });
+
+  it("uses time until the event when sooner than one day", () => {
+    const now = Date.parse("2026-01-01T00:00:00.000Z");
+    const next = Date.parse("2026-01-01T02:00:00.000Z");
+    expect(cdnMaxAgeSeconds(next, now)).toBe(7200);
+  });
+
+  it("is one day when there is no upcoming event", () => {
+    expect(cdnMaxAgeSeconds(undefined, 0)).toBe(CDN_CACHE_MAX_SECONDS);
+  });
+});
+
+describe("soonestExpiryTimestamp", () => {
+  it("returns the earliest still-upcoming expiry", () => {
+    const now = Date.parse("2026-01-01T00:00:00.000Z");
+    expect(
+      soonestExpiryTimestamp(
+        [
+          new Date("2026-01-01T03:00:00.000Z"),
+          new Date("2026-01-01T01:00:00.000Z"),
+        ],
+        now
+      )
+    ).toBe(Date.parse("2026-01-01T01:00:00.000Z"));
+  });
+});

--- a/src/utils/cdn-cache.ts
+++ b/src/utils/cdn-cache.ts
@@ -1,0 +1,75 @@
+export const CDN_CACHE_MAX_SECONDS = 86_400;
+
+export function isUtcMidnight(date: Date): boolean {
+  return (
+    date.getUTCHours() === 0 &&
+    date.getUTCMinutes() === 0 &&
+    date.getUTCSeconds() === 0 &&
+    date.getUTCMilliseconds() === 0
+  );
+}
+
+/**
+ * Instant when an event should drop off "upcoming".
+ * Timed events expire at that timestamp. Date-only values (UTC midnight)
+ * expire at the following UTC midnight so they stay up for that calendar day.
+ */
+export function eventExpiryTimestamp(date: Date): number {
+  if (isUtcMidnight(date)) {
+    return Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate() + 1
+    );
+  }
+  return date.getTime();
+}
+
+export function isEventUpcoming(
+  date: Date,
+  nowMs: number = Date.now()
+): boolean {
+  return eventExpiryTimestamp(date) > nowMs;
+}
+
+export function soonestExpiryTimestamp(
+  dates: Date[],
+  nowMs: number = Date.now()
+): number | undefined {
+  const upcoming = dates
+    .map(eventExpiryTimestamp)
+    .filter((expiry) => expiry > nowMs);
+
+  if (upcoming.length === 0) {
+    return undefined;
+  }
+
+  return Math.min(...upcoming);
+}
+
+export function cdnMaxAgeSeconds(
+  nextExpiryTimestamp: number | undefined,
+  nowMs: number = Date.now()
+): number {
+  if (nextExpiryTimestamp == null) {
+    return CDN_CACHE_MAX_SECONDS;
+  }
+
+  return Math.min(
+    CDN_CACHE_MAX_SECONDS,
+    Math.max(0, Math.floor((nextExpiryTimestamp - nowMs) / 1000))
+  );
+}
+
+export function setCdnCacheHeaders(
+  headers: Headers,
+  nextExpiryTimestamp: number | undefined,
+  nowMs: number = Date.now()
+): void {
+  const maxAge = cdnMaxAgeSeconds(nextExpiryTimestamp, nowMs);
+  headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+  headers.set(
+    "Netlify-CDN-Cache-Control",
+    `public, max-age=${maxAge}, must-revalidate`
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1082.

Search used to be a static Pagefind index, so pages that needed to be searchable had to exist as HTML at build time. That is why listings stayed prerendered or sat behind a long CDN TTL.

Vector search ([#1050](https://github.com/nickytonline/nickytdotco/pull/1050)) indexes Turso on push to `main` instead of crawling static HTML, so these pages can be SSR again. Cache until the next upcoming stream or talk, capped at one day.

- **Watch:** cache until the next upcoming stream; past streams are omitted from Upcoming Live Streams.
- **Talks:** listing is SSR so cache headers apply. Timed talks expire at that timestamp; date-only talks expire at the following UTC midnight. The upcoming pill hides after that.
- **Video archives (`/videos`):** SSR so a livestream that just ended appears in the archive without a deploy. Cache expires at the next upcoming stream (or after one day if nothing is upcoming).

Individual `/videos/[slug]` pages are out of scope here (called out on the issue).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84261f41-807e-4d02-9649-c821940d0937?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84261f41-807e-4d02-9649-c821940d0937&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic CDN caching for the homepage, talks, watch, and videos pages.
  * Pages now cache content until the next scheduled event expires, improving freshness and delivery efficiency.
  * Upcoming events are consistently identified, including date-only events through the end of their calendar day.

* **Bug Fixes**
  * Fixed event listings and schedules to exclude events that have already ended.

* **Tests**
  * Added coverage for event timing, upcoming status, expiry calculations, and cache duration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->