### PR TITLE
fix: run WebMCP search_site without opening the dialog

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,12 +1,6 @@
 import React, { useCallback, useEffect, useId, useRef, useState } from "react";
 import { Loader2, Search as SearchIcon } from "lucide-react";
-import {
-  isSearchQueryTooLong,
-  normalizeSearchQuery,
-  searchSite,
-  type SearchResponse,
-  type SearchResult,
-} from "../lib/search/searchSite";
+import { searchSite, type SearchResult } from "../lib/search/searchSite";
 import {
   SEARCH_ARIA_KEYSHORTCUTS,
   SEARCH_DEBOUNCE_MS,
@@ -160,139 +154,62 @@ const Search = () => {
     }
   };
 
-  const performSearch = useCallback(
-    async (
-      rawQuery: string,
-      options?: { limit?: number; signal?: AbortSignal }
-    ): Promise<
-      | { status: "ok"; response: SearchResponse }
-      | { status: "error"; kind: SearchErrorKind }
-      | { status: "aborted" }
-      | { status: "too-short"; query: string }
-    > => {
-      const trimmed = rawQuery.trim();
-      if (trimmed.length < SEARCH_MIN_QUERY_CHARS) {
-        setResults([]);
-        setSubmittedQuery("");
-        setSearchError(null);
-        setSelectedIndex(-1);
-        return { status: "too-short", query: trimmed };
-      }
-
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
-
-      const onAbort = () => {
-        controller.abort();
-      };
-      options?.signal?.addEventListener("abort", onAbort);
-      if (options?.signal?.aborted) {
-        controller.abort();
-      }
-
-      setIsSearching(true);
+  const performSearch = useCallback(async (rawQuery: string) => {
+    const trimmed = rawQuery.trim();
+    if (trimmed.length < SEARCH_MIN_QUERY_CHARS) {
+      setResults([]);
+      setSubmittedQuery("");
       setSearchError(null);
-      setSubmittedQuery(trimmed);
+      setSelectedIndex(-1);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsSearching(true);
+    setSearchError(null);
+    setSubmittedQuery(trimmed);
+    setResults([]);
+    setSelectedIndex(-1);
+
+    try {
+      const response = await searchSite(trimmed, undefined, controller.signal);
+      setResults(response.results);
+      setSelectedIndex(response.results.length > 0 ? 0 : -1);
+    } catch (error) {
+      if (
+        (error instanceof DOMException && error.name === "AbortError") ||
+        (error instanceof Error && error.name === "AbortError")
+      ) {
+        return;
+      }
+      console.error("Search failed", error);
       setResults([]);
       setSelectedIndex(-1);
-
-      try {
-        const response = await searchSite(
-          trimmed,
-          options?.limit,
-          controller.signal
-        );
-        setResults(response.results);
-        setSelectedIndex(response.results.length > 0 ? 0 : -1);
-        return { status: "ok", response };
-      } catch (error) {
-        if (
-          (error instanceof DOMException && error.name === "AbortError") ||
-          (error instanceof Error && error.name === "AbortError")
-        ) {
-          return { status: "aborted" };
-        }
-        console.error("Search failed", error);
-        setResults([]);
-        setSelectedIndex(-1);
-        const statusCode = (error as { status?: number }).status;
-        const kind: SearchErrorKind =
-          statusCode === 429 ? "rate-limit" : "unavailable";
-        setSearchError(kind);
-        return { status: "error", kind };
-      } finally {
-        options?.signal?.removeEventListener("abort", onAbort);
-        if (!controller.signal.aborted) {
-          setIsSearching(false);
-        }
+      const statusCode = (error as { status?: number }).status;
+      setSearchError(statusCode === 429 ? "rate-limit" : "unavailable");
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsSearching(false);
       }
-    },
-    []
-  );
+    }
+  }, []);
 
   useEffect(() => {
     const registration = new AbortController();
 
-    void registerSearchSiteTool(
-      async (inputObject, { signal }) => {
-        const queryValue =
-          typeof inputObject.query === "string" ? inputObject.query : "";
-        const trimmed = queryValue.trim();
-        const normalized = normalizeSearchQuery(queryValue);
-
-        if (normalized.length < SEARCH_MIN_QUERY_CHARS) {
-          return JSON.stringify({
-            error: `Query must be at least ${SEARCH_MIN_QUERY_CHARS} characters.`,
-          });
-        }
-
-        if (isSearchQueryTooLong(normalized, SEARCH_MAX_QUERY_CHARS)) {
-          return JSON.stringify({
-            error: `Query must be at most ${SEARCH_MAX_QUERY_CHARS} characters.`,
-          });
-        }
-
-        const limit =
-          typeof inputObject.limit === "number" ? inputObject.limit : undefined;
-
-        setSubmittedQuery(trimmed);
-        setIsOpen(true);
-        setQuery(trimmed);
-
-        const outcome = await performSearch(trimmed, { limit, signal });
-
-        if (outcome.status === "ok") {
-          return JSON.stringify({
-            query: outcome.response.query,
-            count: outcome.response.results.length,
-            results: outcome.response.results,
-          });
-        }
-
-        if (outcome.status === "aborted") {
-          return JSON.stringify({ error: "Search was cancelled." });
-        }
-
-        if (outcome.status === "too-short") {
-          return JSON.stringify({
-            error: `Query must be at least ${SEARCH_MIN_QUERY_CHARS} characters.`,
-          });
-        }
-
-        return JSON.stringify({
-          error: SEARCH_ERROR_MESSAGE[outcome.kind],
-        });
-      },
-      { signal: registration.signal }
-    ).catch((error) => {
-      console.error("WebMCP search tool registration failed", error);
-    });
+    void registerSearchSiteTool({ signal: registration.signal }).catch(
+      (error) => {
+        console.error("WebMCP search tool registration failed", error);
+      }
+    );
 
     return () => {
       registration.abort();
     };
-  }, [performSearch]);
+  }, []);
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/lib/webmcp/searchSiteTool.test.ts
+++ b/src/lib/webmcp/searchSiteTool.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SearchResponse } from "../search/types.ts";
+import {
+  executeSearchSiteTool,
+  SEARCH_SITE_TOOL_ERROR,
+} from "./searchSiteTool.ts";
+
+function webpackHits(): SearchResponse {
+  return {
+    query: "webpack",
+    results: [
+      {
+        url: "/blog/webpack",
+        title: "Webpack",
+        excerpt: "A bundler",
+        type: "Post",
+      },
+    ],
+  };
+}
+
+function abortError(): DOMException {
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+describe("executeSearchSiteTool", () => {
+  it("calls searchSite with the query, limit, and abort signal", async () => {
+    const search = vi.fn(async () => webpackHits());
+    const controller = new AbortController();
+
+    const payload = JSON.parse(
+      await executeSearchSiteTool(
+        { query: "webpack", limit: 20 },
+        { signal: controller.signal },
+        search
+      )
+    );
+
+    expect(search).toHaveBeenCalledOnce();
+    expect(search).toHaveBeenCalledWith("webpack", 20, controller.signal);
+    expect(payload).toEqual({
+      query: "webpack",
+      count: 1,
+      results: webpackHits().results,
+    });
+  });
+
+  it("does not call searchSite for a query that is too short", async () => {
+    const search = vi.fn(async () => webpackHits());
+
+    const payload = JSON.parse(
+      await executeSearchSiteTool(
+        { query: "w" },
+        { signal: new AbortController().signal },
+        search
+      )
+    );
+
+    expect(search).not.toHaveBeenCalled();
+    expect(payload).toEqual({
+      error: "Query must be at least 2 characters.",
+    });
+  });
+
+  it("does not call searchSite for a query that is too long", async () => {
+    const search = vi.fn(async () => webpackHits());
+
+    const payload = JSON.parse(
+      await executeSearchSiteTool(
+        { query: "w".repeat(201) },
+        { signal: new AbortController().signal },
+        search
+      )
+    );
+
+    expect(search).not.toHaveBeenCalled();
+    expect(payload).toEqual({
+      error: "Query must be at most 200 characters.",
+    });
+  });
+
+  it("maps a 429 from searchSite to a rate-limit error", async () => {
+    const error = new Error(
+      "Search request failed with status 429"
+    ) as Error & {
+      status: number;
+    };
+    error.status = 429;
+    const search = vi.fn(async () => {
+      throw error;
+    });
+
+    const payload = JSON.parse(
+      await executeSearchSiteTool(
+        { query: "webpack" },
+        { signal: new AbortController().signal },
+        search
+      )
+    );
+
+    expect(payload).toEqual({
+      error: SEARCH_SITE_TOOL_ERROR["rate-limit"],
+    });
+  });
+
+  it("maps other searchSite failures to an unavailable error", async () => {
+    const error = new Error(
+      "Search request failed with status 503"
+    ) as Error & {
+      status: number;
+    };
+    error.status = 503;
+    const search = vi.fn(async () => {
+      throw error;
+    });
+
+    const payload = JSON.parse(
+      await executeSearchSiteTool(
+        { query: "webpack" },
+        { signal: new AbortController().signal },
+        search
+      )
+    );
+
+    expect(payload).toEqual({
+      error: SEARCH_SITE_TOOL_ERROR.unavailable,
+    });
+  });
+
+  it("rejects when searchSite aborts", async () => {
+    const search = vi.fn(async () => {
+      throw abortError();
+    });
+
+    await expect(
+      executeSearchSiteTool(
+        { query: "webpack" },
+        { signal: new AbortController().signal },
+        search
+      )
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("forwards the tool abort signal and rejects when it fires", async () => {
+    const controller = new AbortController();
+    const search = vi.fn(
+      async (
+        _query: string,
+        _limit: number | undefined,
+        signal?: AbortSignal
+      ) => {
+        return await new Promise<SearchResponse>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            reject(abortError());
+          });
+        });
+      }
+    );
+
+    const pending = executeSearchSiteTool(
+      { query: "webpack", limit: 20 },
+      { signal: controller.signal },
+      search
+    );
+
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(search.mock.calls[0]?.[2]).toBe(controller.signal);
+  });
+});

--- a/src/lib/webmcp/searchSiteTool.ts
+++ b/src/lib/webmcp/searchSiteTool.ts
@@ -4,6 +4,11 @@ import {
   SEARCH_MAX_QUERY_CHARS,
   SEARCH_MIN_QUERY_CHARS,
 } from "../search/constants";
+import {
+  isSearchQueryTooLong,
+  normalizeSearchQuery,
+  searchSite,
+} from "../search/searchSite";
 
 export const SEARCH_SITE_TOOL_NAME = "search_site";
 
@@ -12,6 +17,11 @@ export const SEARCH_SITE_TOOL_TITLE = "Search site";
 export const SEARCH_SITE_TOOL_DESCRIPTION =
   "Search nickyt.co for blog posts, conference talks, and livestream videos. " +
   "Returns matching titles, URLs, excerpts, and content types (Post, Talk, or Stream).";
+
+export const SEARCH_SITE_TOOL_ERROR = {
+  "rate-limit": "Too many searches. Wait a moment and try again.",
+  unavailable: "Search is temporarily unavailable. Try again.",
+} as const;
 
 export const searchSiteToolInputSchema = {
   type: "object",
@@ -38,12 +48,67 @@ export type SearchSiteToolInput = {
   limit?: number;
 };
 
+export type SearchSiteFn = typeof searchSite;
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+/**
+ * Headless WebMCP execute callback. Calls `/api/search` via `searchSite()`
+ * and forwards the tool abort signal to fetch. Does not touch the Cmd-K UI.
+ */
+export async function executeSearchSiteTool(
+  inputObject: object,
+  { signal }: { signal: AbortSignal },
+  search: SearchSiteFn = searchSite
+): Promise<string> {
+  const input = inputObject as SearchSiteToolInput;
+  const queryValue = typeof input.query === "string" ? input.query : "";
+  const trimmed = queryValue.trim();
+  const normalized = normalizeSearchQuery(queryValue);
+
+  if (normalized.length < SEARCH_MIN_QUERY_CHARS) {
+    return JSON.stringify({
+      error: `Query must be at least ${SEARCH_MIN_QUERY_CHARS} characters.`,
+    });
+  }
+
+  if (isSearchQueryTooLong(normalized, SEARCH_MAX_QUERY_CHARS)) {
+    return JSON.stringify({
+      error: `Query must be at most ${SEARCH_MAX_QUERY_CHARS} characters.`,
+    });
+  }
+
+  const limit = typeof input.limit === "number" ? input.limit : undefined;
+
+  try {
+    const response = await search(trimmed, limit, signal);
+    return JSON.stringify({
+      query: response.query,
+      count: response.results.length,
+      results: response.results,
+    });
+  } catch (error) {
+    if (isAbortError(error) || signal.aborted) {
+      throw error;
+    }
+    const statusCode = (error as { status?: number }).status;
+    const kind = statusCode === 429 ? "rate-limit" : "unavailable";
+    return JSON.stringify({
+      error: SEARCH_SITE_TOOL_ERROR[kind],
+    });
+  }
+}
+
 /**
  * Registers the site search tool with WebMCP when the API is present.
  * Returns false when WebMCP is unavailable (no-op progressive enhancement).
  */
 export async function registerSearchSiteTool(
-  execute: WebMCP.ToolExecuteCallback,
   options?: WebMCP.ModelContextRegisterToolOptions
 ): Promise<boolean> {
   const modelContext = document.modelContext;
@@ -60,7 +125,8 @@ export async function registerSearchSiteTool(
       annotations: {
         readOnlyHint: true,
       },
-      execute,
+      execute: (inputObject, executeOptions) =>
+        executeSearchSiteTool(inputObject, executeOptions),
     },
     options
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #1060.

`search_site` was reusing the Cmd-K search controller, so a WebMCP call like `search_site({ query: "webpack", limit: 20 })` opened the visible search dialog. WebMCP does not require that: `readOnlyHint: true` only means the tool should not mutate external data, and abort is already provided as `execute`’s `{ signal }`.

## What changed

- Tool execute now calls `/api/search` through `searchSite()` directly
- The WebMCP abort signal is forwarded to `fetch`; abort rejects instead of returning a JSON error
- Cmd-K search keeps its own abort controller (closing the dialog still cancels in-flight UI searches only)
- Registration no longer closes over React dialog state

## How to test

1. Wait for the Netlify deploy preview
2. Open the preview in a WebMCP-capable client (ChatGPT in-app browser or Chrome with WebMCP)
3. Call `search_site({ query: "webpack", limit: 20 })`
4. Confirm structured results come back **and the search dialog stays closed**
5. Confirm Cmd-K / `/` search still opens and works as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f3ca4bc-be57-4ded-b72c-28bc68812d02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f3ca4bc-be57-4ded-b72c-28bc68812d02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a WebMCP-powered site search tool that validates queries, supports optional result limits, and returns search results.
  * Added clear handling for invalid queries, rate limits, unavailable search services, and canceled requests.

* **Bug Fixes**
  * Improved search tool registration and error reporting.
  * Ensured cancellation signals are correctly passed through during searches.

* **Tests**
  * Added comprehensive coverage for successful searches, validation, error handling, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->