### PR TITLE
fix: show talk and stream thumbnails above titles on small screens

### DIFF
--- a/src/components/LiveStreamCard.astro
+++ b/src/components/LiveStreamCard.astro
@@ -39,7 +39,7 @@ const {
 } = Astro.props;
 ---
 
-<div class="stream-card group grid md:flex gap-6 xl:gap-8">
+<div class="stream-card group grid md:flex gap-3 md:gap-6 xl:gap-8">
   {
     image &&
       (videoLink ? (

--- a/src/components/LiveStreamCard.astro
+++ b/src/components/LiveStreamCard.astro
@@ -45,7 +45,7 @@ const {
       (videoLink ? (
         <a
           href={videoLink}
-          class="relative shrink-0 hidden md:block w-40 h-22.5 rounded-lg overflow-hidden"
+          class="relative shrink-0 w-full aspect-video rounded-lg overflow-hidden md:w-40 md:h-22.5 md:aspect-auto"
           aria-hidden="true"
           tabindex="-1"
         >
@@ -60,7 +60,7 @@ const {
           />
         </a>
       ) : (
-        <div class="relative shrink-0 hidden md:block w-40 h-22.5 rounded-lg overflow-hidden">
+        <div class="relative shrink-0 w-full aspect-video rounded-lg overflow-hidden md:w-40 md:h-22.5 md:aspect-auto">
           <Image
             src={image}
             alt=""

--- a/src/components/TalkCard.astro
+++ b/src/components/TalkCard.astro
@@ -54,7 +54,7 @@ if (coverImage) {
   >
     {
       thumbnailUrl ? (
-        <div class="relative shrink-0 hidden md:block w-40 h-22.5 rounded-lg overflow-hidden bg-muted">
+        <div class="relative shrink-0 w-full aspect-video rounded-lg overflow-hidden bg-muted md:w-40 md:h-22.5 md:aspect-auto">
           <Image
             src={thumbnailUrl}
             alt=""
@@ -66,7 +66,7 @@ if (coverImage) {
           />
         </div>
       ) : (
-        <div class="relative shrink-0 hidden md:block w-40 h-22.5 rounded-lg overflow-hidden bg-muted flex items-center justify-center">
+        <div class="relative shrink-0 w-full aspect-video rounded-lg overflow-hidden bg-muted flex items-center justify-center md:w-40 md:h-22.5 md:aspect-auto">
           {/* subtle dot grid */}
           <svg
             class="absolute inset-0 w-full h-full opacity-[0.07]"

--- a/src/components/TalkCard.astro
+++ b/src/components/TalkCard.astro
@@ -50,7 +50,7 @@ if (coverImage) {
 <article>
   <a
     href={href}
-    class="group grid md:flex gap-6 xl:gap-8 no-underline outline-none transition-colors"
+    class="group grid md:flex gap-3 md:gap-6 xl:gap-8 no-underline outline-none transition-colors"
   >
     {
       thumbnailUrl ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On small screens, talk and stream event cards no longer hide their thumbnails. Thumbnails now appear full-width above each title, while desktop keeps the existing left-side layout.

## Changes

- **TalkCard**: Removed `hidden md:block` and use full-width `aspect-video` on mobile, switching to the fixed `w-40 h-22.5` thumbnail at `md+`.
- **LiveStreamCard**: Same responsive thumbnail treatment for stream events in Upcoming Events / Latest.

## Layout

| Breakpoint | Thumbnail placement |
|------------|---------------------|
| `< md` | Full-width 16:9 image above title |
| `≥ md` | Fixed thumbnail to the left of content (unchanged) |

## Testing

- Verified on mobile viewport (375px): talk cards in Start here and Upcoming Events show thumbnails above titles.
- Stream cards use the same pattern; local dev could not load live schedule data, but the markup mirrors TalkCard.

[Mobile talk card with thumbnail above title](https://cursor.com/agents/bc-01a05812-3363-7ca0-9036-b3cfd9c60a3b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmobile-talk-thumbnail-above-title.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05812-3363-7ca0-9036-b3cfd9c60a3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05812-3363-7ca0-9036-b3cfd9c60a3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thumbnails for live streams and talks now display on mobile devices instead of being hidden.
  * Mobile thumbnails use a consistent 16:9 layout and full width.
  * Improved spacing between thumbnails and card content on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->