### PR TITLE
fix: show iximiuz guide thumbnails above titles on small screens

### DIFF
--- a/src/components/GuideCard.astro
+++ b/src/components/GuideCard.astro
@@ -21,11 +21,11 @@ const { title, description, date, coverImage, href, source, category } =
     href={href}
     target="_blank"
     rel="noopener noreferrer"
-    class="group grid md:flex gap-6 xl:gap-8 no-underline outline-none transition-colors"
+    class="group grid md:flex gap-3 md:gap-6 xl:gap-8 no-underline outline-none transition-colors"
   >
     {
       coverImage ? (
-        <div class="relative shrink-0 hidden md:block w-40 h-22.5 rounded-lg overflow-hidden bg-muted">
+        <div class="relative shrink-0 w-full aspect-video rounded-lg overflow-hidden bg-muted md:w-40 md:h-22.5 md:aspect-auto">
           <Image
             src={coverImage}
             alt=""
@@ -37,7 +37,7 @@ const { title, description, date, coverImage, href, source, category } =
           />
         </div>
       ) : (
-        <div class="relative shrink-0 hidden md:flex w-40 h-22.5 rounded-lg overflow-hidden bg-muted items-center justify-center">
+        <div class="relative shrink-0 w-full aspect-video rounded-lg overflow-hidden bg-muted flex items-center justify-center md:w-40 md:h-22.5 md:aspect-auto">
           <svg
             class="w-8 h-8 text-muted-foreground/50"
             fill="none"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apply the same mobile thumbnail treatment to `GuideCard` (iximiuz Labs hands-on tutorials in Start here).

## Changes

- Show full-width 16:9 cover images above titles on small screens
- Tighter mobile gap (`gap-3`) between thumbnail and title
- Desktop layout unchanged (thumbnail left at `w-40`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05812-3363-7ca0-9036-b3cfd9c60a3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05812-3363-7ca0-9036-b3cfd9c60a3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Guide card thumbnails and placeholders now appear on mobile devices.
  * Mobile thumbnails use full width with a video-style aspect ratio, while larger screens retain their existing dimensions.
  * Adjusted spacing between card content and links for improved responsive layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->