### PR TITLE
fix: make explore hub buttons full width when stacked

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -267,16 +267,16 @@ export const prerender = false;
             A few selected talks, tutorials, and practical notes on AI, Zero
             Trust security, and developer infrastructure.
           </p>
-          <div class="flex flex-wrap gap-3 pt-2">
+          <div class="flex flex-col flex-wrap gap-3 pt-2 md:flex-row">
             <a
               href="/mcp"
-              class="inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-base font-semibold text-foreground transition-colors hover:bg-secondary focus:bg-secondary focus:outline-none"
+              class="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-border px-5 py-2.5 text-base font-semibold text-foreground transition-colors hover:bg-secondary focus:bg-secondary focus:outline-none md:w-auto md:justify-start"
             >
               Explore the MCP hub
             </a>
             <a
               href="/zero-trust-security"
-              class="inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-base font-semibold text-foreground transition-colors hover:bg-secondary focus:bg-secondary focus:outline-none"
+              class="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-border px-5 py-2.5 text-base font-semibold text-foreground transition-colors hover:bg-secondary focus:bg-secondary focus:outline-none md:w-auto md:justify-start"
             >
               Explore the Zero Trust security hub
             </a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the homepage "Start here" section, the MCP and Zero Trust hub explore buttons now span the full container width when stacked on narrow viewports, instead of sizing to their text content and appearing mismatched.

## Changes

- Stack hub buttons vertically below the `md` breakpoint
- Apply `w-full` on narrow viewports and revert to content width from `md` up
- Center button labels when full width for a cleaner mobile layout

## Test plan

- [x] Verified on mobile viewport that both hub buttons are equal full width when stacked
- [x] Verified on desktop that buttons remain inline with content-based width
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05843-9ad4-703f-b1fb-bbc98d2b27dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05843-9ad4-703f-b1fb-bbc98d2b27dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the responsiveness of the “Start here” hub links.
  * Hub buttons now stack vertically and span the available width on small screens, while retaining their horizontal layout on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->