### PR TITLE
fix: make mobile menu links full-width tap targets

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -183,7 +183,7 @@ test.describe("home page mobile CTAs", () => {
     const box = await speakingLink.boundingBox();
     expect(box).not.toBeNull();
 
-    await page.mouse.click(box!.x + 8, box!.y + box!.height / 2);
+    await speakingLink.click({ position: { x: 8, y: box!.height / 2 } });
 
     await expect(page).toHaveURL(/\/speaking\/?$/);
     await expect(

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -168,3 +168,26 @@ test.describe("home page", () => {
     );
   });
 });
+
+test.describe("home page mobile CTAs", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("hero CTAs are full-width and clickable across the row", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const speakingLink = page.getByRole("link", {
+      name: "Speaking & guest appearances",
+    });
+    const box = await speakingLink.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.click(box!.x + 8, box!.y + box!.height / 2);
+
+    await expect(page).toHaveURL(/\/speaking\/?$/);
+    await expect(
+      page.getByRole("main").getByRole("heading", { level: 1 })
+    ).toBeVisible();
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -116,6 +116,26 @@ test.describe("mobile navigation", () => {
     ).toBeVisible();
   });
 
+  test("menu links are clickable across the full row width", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const menu = page.locator("[data-mobile-menu]");
+    await menu.locator("summary").click();
+
+    const blogLink = menu.getByRole("link", { name: "Blog", exact: true });
+    const box = await blogLink.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.click(box!.x + 8, box!.y + box!.height / 2);
+
+    await expect(page).toHaveURL(/\/blog\/?$/);
+    await expect(
+      page.getByRole("main").getByRole("heading", { level: 1 })
+    ).toBeVisible();
+  });
+
   test("menu closes when clicking outside it", async ({ page }) => {
     await page.goto("/");
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -77,13 +77,13 @@ const isCurrent = (href: string) =>
           aria-label="main navigation"
           class="absolute left-0 right-0 top-full z-50 mt-2 rounded-lg border border-border bg-background p-4 text-lg shadow-lg"
         >
-          <ul class="flex list-none flex-col items-center gap-3">
+          <ul class="flex list-none flex-col gap-1">
             {navItems.map((item) => (
-              <li>
+              <li class="w-full">
                 <a
                   href={item.href}
                   aria-current={isCurrent(item.href) ? "page" : undefined}
-                  class="nav-link"
+                  class="nav-link block w-full rounded-lg px-4 py-2 text-center hover:bg-secondary focus-visible:bg-secondary"
                 >
                   {item.label}
                 </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -233,10 +233,10 @@ export const prerender = false;
           I'm currently in developer relations at
           <a href="https://pomerium.com">Pomerium</a>.
         </p>
-        <div class="flex flex-wrap gap-4 pt-2">
+        <div class="flex flex-col gap-4 pt-2 md:flex-row md:flex-wrap">
           <a
             href="/speaking"
-            class="inline-flex items-center rounded-lg bg-brand-solid px-5 py-2.5 text-base font-semibold text-brand-foreground transition-colors hover:bg-brand-solid-hover focus:bg-brand-solid-hover focus:outline-none"
+            class="inline-flex w-full items-center justify-center rounded-lg bg-brand-solid px-5 py-2.5 text-base font-semibold text-brand-foreground transition-colors hover:bg-brand-solid-hover focus:bg-brand-solid-hover focus:outline-none md:w-auto"
           >
             Speaking &amp; guest appearances
           </a>
@@ -244,7 +244,7 @@ export const prerender = false;
             href="https://OneTipAWeek.com?utm_source=nickytco&utm_medium=homepage-hero"
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center rounded-lg border border-border px-5 py-2.5 text-base font-semibold text-foreground transition-colors hover:bg-secondary focus:bg-secondary focus:outline-none"
+            class="inline-flex w-full items-center justify-center rounded-lg border border-border px-5 py-2.5 text-base font-semibold text-foreground transition-colors hover:bg-secondary focus:bg-secondary focus:outline-none md:w-auto"
           >
             Get one dev tip a week
           </a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On mobile, navigation menu items and homepage hero CTAs were only clickable on the link text because anchors did not stretch to their container width. Both are now full-width block links with centered text and comfortable tap targets.

## Changes

- **Mobile nav**: menu links use `block w-full` with horizontal padding and rounded hover/focus backgrounds
- **Hero CTAs**: stack vertically on small screens with `w-full justify-center` labels; revert to inline sizing from `md` breakpoint up
- **E2E**: added tests that click the left edge of a menu row and hero CTA to verify full-width tap targets on mobile

## Test plan

- [x] Formatting passes (`vp fmt --check .`)
- [ ] E2E tests pass on deploy preview
- [ ] All required CI checks green before merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05845-52d9-7053-aa8f-7c9f0004d1f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05845-52d9-7053-aa8f-7c9f0004d1f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved mobile navigation links with full-row clickable areas.
  - Added clearer spacing, alignment, and hover/focus feedback for mobile menu items.

- **Bug Fixes**
  - Fixed mobile navigation behavior so tapping across a menu link reliably opens the correct page.

- **Tests**
  - Added coverage verifying links can be activated from different points across their full width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->