### PR TITLE
feat: refresh project star counts from GitHub every few days

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -69,8 +69,26 @@ const { project } = Astro.props;
       </div>
     </div>
 
+    <details class="project-card-details group/details mb-4 flex-1 lg:hidden">
+      <summary
+        class="list-none cursor-pointer [&::-webkit-details-marker]:hidden focus-visible:outline-2 focus-visible:outline-brand focus-visible:outline-offset-2 rounded-md"
+      >
+        <p
+          class="text-muted-foreground text-sm leading-relaxed line-clamp-3 group-open/details:line-clamp-none"
+        >
+          {project.description}
+        </p>
+        <span
+          class="relative z-10 mt-2 inline-block text-xs font-medium text-brand hover:underline"
+        >
+          <span class="group-open/details:hidden">Show more</span>
+          <span class="hidden group-open/details:inline">Show less</span>
+        </span>
+      </summary>
+    </details>
+
     <div
-      class="project-card-description mb-4 flex-1 min-h-18 max-h-18 overflow-y-auto overscroll-contain pr-1"
+      class="project-card-description mb-4 flex-1 min-h-18 max-h-18 overflow-y-auto overscroll-contain pr-1 hidden lg:block"
       tabindex="0"
     >
       <p class="text-muted-foreground text-sm leading-relaxed">

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -69,9 +69,14 @@ const { project } = Astro.props;
       </div>
     </div>
 
-    <p class="text-muted-foreground text-sm mb-4 flex-1 line-clamp-3">
-      {project.description}
-    </p>
+    <div
+      class="project-card-description mb-4 flex-1 min-h-18 max-h-18 overflow-y-auto overscroll-contain pr-1"
+      tabindex="0"
+    >
+      <p class="text-muted-foreground text-sm leading-relaxed">
+        {project.description}
+      </p>
+    </div>
 
     {
       project.myRole && (
@@ -142,3 +147,30 @@ const { project } = Astro.props;
     }
   </div>
 </article>
+
+<style>
+  .project-card-description {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--muted-foreground) 40%, transparent)
+      transparent;
+  }
+
+  .project-card-description::-webkit-scrollbar {
+    width: 0.375rem;
+  }
+
+  .project-card-description::-webkit-scrollbar-thumb {
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 35%,
+      transparent
+    );
+    border-radius: 9999px;
+  }
+
+  .project-card-description:focus-visible {
+    outline: 2px solid var(--brand);
+    outline-offset: 2px;
+    border-radius: 0.375rem;
+  }
+</style>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -69,26 +69,8 @@ const { project } = Astro.props;
       </div>
     </div>
 
-    <details class="project-card-details group/details mb-4 flex-1 lg:hidden">
-      <summary
-        class="list-none cursor-pointer [&::-webkit-details-marker]:hidden focus-visible:outline-2 focus-visible:outline-brand focus-visible:outline-offset-2 rounded-md"
-      >
-        <p
-          class="text-muted-foreground text-sm leading-relaxed line-clamp-3 group-open/details:line-clamp-none"
-        >
-          {project.description}
-        </p>
-        <span
-          class="relative z-10 mt-2 inline-block text-xs font-medium text-brand hover:underline"
-        >
-          <span class="group-open/details:hidden">Show more</span>
-          <span class="hidden group-open/details:inline">Show less</span>
-        </span>
-      </summary>
-    </details>
-
     <div
-      class="project-card-description mb-4 flex-1 min-h-18 max-h-18 overflow-y-auto overscroll-contain pr-1 hidden lg:block"
+      class="project-card-description mb-4 flex-1 pr-1 lg:min-h-18 lg:max-h-18 lg:overflow-y-auto lg:overscroll-contain"
       tabindex="0"
     >
       <p class="text-muted-foreground text-sm leading-relaxed">

--- a/src/data/curated-projects.ts
+++ b/src/data/curated-projects.ts
@@ -1,0 +1,121 @@
+export interface ProjectLink {
+  label: string;
+  url: string;
+}
+
+export interface CuratedProjectBase {
+  owner: string;
+  name: string;
+  description: string;
+  url: string;
+  myRole?: string;
+  links?: ProjectLink[];
+  primaryLanguage?: { name: string; color: string };
+  /** Shown on the homepage featured card instead of `description`. */
+  featuredDescription?: string;
+  /** Shown on the homepage featured card instead of `links`. */
+  featuredLinks?: ProjectLink[];
+  /** Used when GitHub stats are unavailable. */
+  fallbackStats?: { stargazerCount: number; forkCount: number };
+}
+
+export const curatedProjects: CuratedProjectBase[] = [
+  {
+    owner: "nickytonline",
+    name: "mcp-typescript-template",
+    description:
+      "Production-ready starter for building MCP servers in TypeScript. No build step needed during development, Vite for production, Vitest for testing, Pino logging, and Docker support out of the box.",
+    featuredDescription:
+      "Production-ready starter for building MCP servers in TypeScript, with Vite, Vitest, Pino logging, and Docker support out of the box.",
+    url: "https://github.com/nickytonline/mcp-typescript-template",
+    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
+    myRole: "Author & maintainer",
+    links: [
+      {
+        label: "Blog post",
+        url: "/blog/build-your-first-or-next-mcp-server-with-the-typescript-mcp-template/",
+      },
+    ],
+    featuredLinks: [
+      {
+        label: "Read the build story",
+        url: "/blog/build-your-first-or-next-mcp-server-with-the-typescript-mcp-template/",
+      },
+    ],
+    fallbackStats: { stargazerCount: 55, forkCount: 12 },
+  },
+  {
+    owner: "pomerium",
+    name: "mcp-app-typescript-template",
+    description:
+      "A well-architected starter for building MCP Apps with TypeScript, React widgets, the OpenAI Apps SDK, and Pomerium. Includes a Node.js server, Storybook, Vitest, and production-ready patterns.",
+    url: "https://github.com/pomerium/mcp-app-typescript-template",
+    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
+    myRole: "Author & maintainer",
+    fallbackStats: { stargazerCount: 19, forkCount: 7 },
+  },
+  {
+    owner: "pomerium",
+    name: "mcp-app-demo",
+    description:
+      "A full chat client that started as a demo for securing MCP servers with Pomerium and grew into a real application. Supports multiple MCP servers with Zero Trust access control. Used internally and at conference demos.",
+    url: "https://github.com/pomerium/mcp-app-demo",
+    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
+    myRole: "Author & maintainer",
+    fallbackStats: { stargazerCount: 51, forkCount: 7 },
+  },
+  {
+    owner: "openclaw",
+    name: "openclaw",
+    description:
+      "Open-source personal AI assistant you run on your own devices, supporting 20+ messaging channels. I contributed the Trusted Proxy authentication mode — hardening access to the control plane UI and SSH.",
+    url: "https://github.com/openclaw/openclaw",
+    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
+    myRole: "Contributor",
+    links: [
+      { label: "Setup guide", url: "https://usepom.link/claw-guide" },
+      {
+        label: "AI Engineer Europe 2026 talk",
+        url: "/talks/claws-out-securing-and-building-with-openclaw-ai-engineer-europe-2026",
+      },
+    ],
+    fallbackStats: { stargazerCount: 381855, forkCount: 80092 },
+  },
+  {
+    owner: "nickytonline",
+    name: "dev-to-mcp",
+    description:
+      "A remote MCP server for the dev.to public API — no authentication required. Browse articles, search content, fetch user profiles, and pull comments from dev.to via any MCP-compatible client.",
+    url: "https://github.com/nickytonline/dev-to-mcp",
+    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
+    myRole: "Author & maintainer",
+    links: [
+      {
+        label: "Blog post",
+        url: "/blog/introducing-the-devto-mcp-server/",
+      },
+    ],
+    fallbackStats: { stargazerCount: 44, forkCount: 15 },
+  },
+  {
+    owner: "nickytonline",
+    name: "clawspace",
+    description:
+      "Browser-based file explorer and editor for OpenClaw workspaces. Monaco editor (the same engine powering VS Code), file browsing, editing, saving, and reverting — faster than reaching for a terminal for quick workspace edits.",
+    url: "https://github.com/nickytonline/clawspace",
+    primaryLanguage: { name: "Astro", color: "#FF5D01" },
+    myRole: "Author & maintainer",
+    links: [
+      {
+        label: "Blog post",
+        url: "/blog/clawspace-a-browser-based-file-explorer-for-openclaw/",
+      },
+    ],
+    fallbackStats: { stargazerCount: 11, forkCount: 0 },
+  },
+];
+
+export const featuredProjectRef = {
+  owner: "nickytonline",
+  name: "mcp-typescript-template",
+} as const;

--- a/src/lib/github/enrichCuratedProjects.test.ts
+++ b/src/lib/github/enrichCuratedProjects.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { curatedProjects } from "../../data/curated-projects";
+import {
+  enrichCuratedProjects,
+  toFeaturedProject,
+} from "./enrichCuratedProjects";
+
+describe("enrichCuratedProjects", () => {
+  it("merges live GitHub stats with curated project copy", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({
+        data: {
+          repo0: {
+            stargazerCount: 99,
+            forkCount: 21,
+            primaryLanguage: { name: "TypeScript", color: "#3178c6" },
+          },
+        },
+      })
+    );
+
+    const [project] = await enrichCuratedProjects([curatedProjects[0]!], {
+      fetch,
+      githubToken: "ghp_test",
+    });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(project.stargazerCount).toBe(99);
+    expect(project.forkCount).toBe(21);
+    expect(project.description).toContain("Production-ready starter");
+    expect(project.primaryLanguage).toEqual({
+      name: "TypeScript",
+      color: "var(--typescript)",
+    });
+  });
+
+  it("falls back to cached stats when GitHub is unavailable", async () => {
+    const fetch = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    const [project] = await enrichCuratedProjects([curatedProjects[0]!], {
+      fetch,
+      githubToken: "ghp_test",
+    });
+
+    expect(project.stargazerCount).toBe(55);
+    expect(project.forkCount).toBe(12);
+  });
+});
+
+describe("toFeaturedProject", () => {
+  it("uses homepage-specific copy when present", () => {
+    const featured = toFeaturedProject(curatedProjects[0]!, {
+      stargazerCount: 77,
+      forkCount: 8,
+    });
+
+    expect(featured.description).toContain("with Vite, Vitest, Pino logging");
+    expect(featured.links?.[0]?.label).toBe("Read the build story");
+    expect(featured.stargazerCount).toBe(77);
+  });
+});

--- a/src/lib/github/enrichCuratedProjects.ts
+++ b/src/lib/github/enrichCuratedProjects.ts
@@ -1,0 +1,81 @@
+import type { CuratedProjectBase } from "../../data/curated-projects";
+import {
+  fetchRepositoryStats,
+  type RepositoryRef,
+  type RepositoryStats,
+} from "./fetchRepositoryStats";
+
+export interface EnrichedProject {
+  owner: string;
+  name: string;
+  description: string;
+  url: string;
+  stargazerCount: number;
+  forkCount: number;
+  primaryLanguage?: { name: string; color: string } | null;
+  myRole?: string;
+  links?: CuratedProjectBase["links"];
+}
+
+function repositoryKey(owner: string, name: string): string {
+  return `${owner}/${name}`;
+}
+
+export async function enrichCuratedProjects(
+  projects: CuratedProjectBase[],
+  deps: {
+    fetch?: typeof globalThis.fetch;
+    githubToken?: string;
+  } = {}
+): Promise<EnrichedProject[]> {
+  const repositories: RepositoryRef[] = projects.map((project) => ({
+    owner: project.owner,
+    name: project.name,
+  }));
+
+  let statsByRepo = new Map<string, RepositoryStats>();
+
+  try {
+    statsByRepo = await fetchRepositoryStats(repositories, deps);
+  } catch (error) {
+    console.warn(
+      "Could not fetch GitHub repository stats; using fallback values where available.",
+      error
+    );
+  }
+
+  return projects.map((project) => {
+    const stats = statsByRepo.get(repositoryKey(project.owner, project.name));
+    const fallback = project.fallbackStats;
+
+    return {
+      owner: project.owner,
+      name: project.name,
+      description: project.description,
+      url: project.url,
+      myRole: project.myRole,
+      links: project.links,
+      stargazerCount: stats?.stargazerCount ?? fallback?.stargazerCount ?? 0,
+      forkCount: stats?.forkCount ?? fallback?.forkCount ?? 0,
+      primaryLanguage:
+        project.primaryLanguage ?? stats?.primaryLanguage ?? null,
+    };
+  });
+}
+
+export function toFeaturedProject(
+  project: CuratedProjectBase,
+  stats: Pick<EnrichedProject, "stargazerCount" | "forkCount">
+): EnrichedProject {
+  return {
+    owner: project.owner,
+    name: project.name,
+    description: project.featuredDescription ?? project.description,
+    url: project.url,
+    myRole: project.myRole,
+    links: project.featuredLinks ?? project.links,
+    stargazerCount: stats.stargazerCount,
+    forkCount: stats.forkCount,
+    primaryLanguage: project.primaryLanguage ?? null,
+  };
+}

--- a/src/lib/github/fetchRepositoryStats.ts
+++ b/src/lib/github/fetchRepositoryStats.ts
@@ -1,0 +1,104 @@
+import { ENV } from "varlock/env";
+
+export interface RepositoryRef {
+  owner: string;
+  name: string;
+}
+
+export interface RepositoryStats {
+  stargazerCount: number;
+  forkCount: number;
+  primaryLanguage?: { name: string; color: string } | null;
+}
+
+interface GraphQLRepository {
+  stargazerCount: number;
+  forkCount: number;
+  primaryLanguage?: { name: string; color: string } | null;
+}
+
+interface GraphQLResponse {
+  data?: Record<string, GraphQLRepository | null>;
+  errors?: Array<{ message: string }>;
+}
+
+function repositoryKey(owner: string, name: string): string {
+  return `${owner}/${name}`;
+}
+
+function buildStatsQuery(repositories: RepositoryRef[]): string {
+  const fields = repositories
+    .map(
+      (repo, index) => `
+    repo${index}: repository(owner: ${JSON.stringify(repo.owner)}, name: ${JSON.stringify(repo.name)}) {
+      stargazerCount
+      forkCount
+      primaryLanguage {
+        name
+        color
+      }
+    }`
+    )
+    .join("\n");
+
+  return `query FetchRepositoryStats {${fields}\n}`;
+}
+
+export async function fetchRepositoryStats(
+  repositories: RepositoryRef[],
+  deps: {
+    fetch?: typeof globalThis.fetch;
+    githubToken?: string;
+  } = {}
+): Promise<Map<string, RepositoryStats>> {
+  const stats = new Map<string, RepositoryStats>();
+
+  if (repositories.length === 0) {
+    return stats;
+  }
+
+  const fetchImpl = deps.fetch ?? fetch;
+  const githubToken = deps.githubToken ?? ENV.GITHUB_TOKEN;
+
+  const response = await fetchImpl("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${githubToken}`,
+    },
+    body: JSON.stringify({ query: buildStatsQuery(repositories) }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub GraphQL request failed: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const json = (await response.json()) as GraphQLResponse;
+
+  if (json.errors?.length) {
+    console.warn(
+      `GitHub GraphQL partial error: ${json.errors.map((error) => error.message).join(", ")}`
+    );
+  }
+
+  if (!json.data) {
+    throw new Error("GitHub GraphQL response did not include repository data.");
+  }
+
+  for (const [index, repo] of repositories.entries()) {
+    const node = json.data[`repo${index}`];
+    if (!node) {
+      continue;
+    }
+
+    stats.set(repositoryKey(repo.owner, repo.name), {
+      stargazerCount: node.stargazerCount,
+      forkCount: node.forkCount,
+      primaryLanguage: node.primaryLanguage,
+    });
+  }
+
+  return stats;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,14 @@ import TalkCard from "../components/TalkCard.astro";
 import GuideCard from "../components/GuideCard.astro";
 import ProjectCard from "../components/ProjectCard.astro";
 import {
+  curatedProjects,
+  featuredProjectRef,
+} from "../data/curated-projects";
+import {
+  enrichCuratedProjects,
+  toFeaturedProject,
+} from "../lib/github/enrichCuratedProjects";
+import {
   isEventUpcoming,
   setCdnCacheHeaders,
   soonestExpiryTimestamp,
@@ -71,23 +79,18 @@ const featuredGuides = sortedGuides
   .filter((g) => g.data.featured === true)
   .slice(0, 2);
 
-const featuredProject = {
-  owner: "nickytonline",
-  name: "mcp-typescript-template",
-  description:
-    "Production-ready starter for building MCP servers in TypeScript, with Vite, Vitest, Pino logging, and Docker support out of the box.",
-  url: "https://github.com/nickytonline/mcp-typescript-template",
-  stargazerCount: 55,
-  forkCount: 12,
-  primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
-  myRole: "Author & maintainer",
-  links: [
-    {
-      label: "Read the build story",
-      url: "/blog/build-your-first-or-next-mcp-server-with-the-typescript-mcp-template/",
-    },
-  ],
-};
+const featuredProjectBase = curatedProjects.find(
+  (project) =>
+    project.owner === featuredProjectRef.owner &&
+    project.name === featuredProjectRef.name,
+)!;
+const [featuredProjectStats] = await enrichCuratedProjects([
+  featuredProjectBase,
+]);
+const featuredProject = toFeaturedProject(
+  featuredProjectBase,
+  featuredProjectStats,
+);
 
 const locale =
   Astro.request.headers.get("Accept-Language")?.split(",")[0] ||

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -2,119 +2,18 @@
 import Layout from "../layouts/MainLayout.astro";
 import SectionHeader from "../components/SectionHeader.astro";
 import ProjectCard from "../components/ProjectCard.astro";
+import { curatedProjects } from "../data/curated-projects";
+import { enrichCuratedProjects } from "../lib/github/enrichCuratedProjects";
+import {
+  PROJECTS_CACHE_MAX_SECONDS,
+  setFixedCdnCacheHeaders,
+} from "../utils/cdn-cache";
 
-export const prerender = true;
+const projects = await enrichCuratedProjects(curatedProjects);
 
-interface ProjectLink {
-  label: string;
-  url: string;
-}
+setFixedCdnCacheHeaders(Astro.response.headers, PROJECTS_CACHE_MAX_SECONDS);
 
-interface CuratedProject {
-  owner: string;
-  name: string;
-  description: string;
-  url: string;
-  stargazerCount: number;
-  forkCount: number;
-  primaryLanguage?: { name: string; color: string } | null;
-  myRole?: string;
-  links?: ProjectLink[];
-}
-
-const projects: CuratedProject[] = [
-  {
-    owner: "nickytonline",
-    name: "mcp-typescript-template",
-    description:
-      "Production-ready starter for building MCP servers in TypeScript. No build step needed during development, Vite for production, Vitest for testing, Pino logging, and Docker support out of the box.",
-    url: "https://github.com/nickytonline/mcp-typescript-template",
-    stargazerCount: 55,
-    forkCount: 12,
-    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
-    myRole: "Author & maintainer",
-    links: [
-      {
-        label: "Blog post",
-        url: "/blog/build-your-first-or-next-mcp-server-with-the-typescript-mcp-template/",
-      },
-    ],
-  },
-  {
-    owner: "pomerium",
-    name: "mcp-app-typescript-template",
-    description:
-      "A well-architected starter for building MCP Apps with TypeScript, React widgets, the OpenAI Apps SDK, and Pomerium. Includes a Node.js server, Storybook, Vitest, and production-ready patterns.",
-    url: "https://github.com/pomerium/mcp-app-typescript-template",
-    stargazerCount: 19,
-    forkCount: 7,
-    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
-    myRole: "Author & maintainer",
-  },
-  {
-    owner: "pomerium",
-    name: "mcp-app-demo",
-    description:
-      "A full chat client that started as a demo for securing MCP servers with Pomerium and grew into a real application. Supports multiple MCP servers with Zero Trust access control. Used internally and at conference demos.",
-    url: "https://github.com/pomerium/mcp-app-demo",
-    stargazerCount: 51,
-    forkCount: 7,
-    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
-    myRole: "Author & maintainer",
-  },
-  {
-    owner: "openclaw",
-    name: "openclaw",
-    description:
-      "Open-source personal AI assistant you run on your own devices, supporting 20+ messaging channels. I contributed the Trusted Proxy authentication mode — hardening access to the control plane UI and SSH.",
-    url: "https://github.com/openclaw/openclaw",
-    stargazerCount: 381855,
-    forkCount: 80092,
-    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
-    myRole: "Contributor",
-    links: [
-      { label: "Setup guide", url: "https://usepom.link/claw-guide" },
-      {
-        label: "AI Engineer Europe 2026 talk",
-        url: "/talks/claws-out-securing-and-building-with-openclaw-ai-engineer-europe-2026",
-      },
-    ],
-  },
-  {
-    owner: "nickytonline",
-    name: "dev-to-mcp",
-    description:
-      "A remote MCP server for the dev.to public API — no authentication required. Browse articles, search content, fetch user profiles, and pull comments from dev.to via any MCP-compatible client.",
-    url: "https://github.com/nickytonline/dev-to-mcp",
-    stargazerCount: 44,
-    forkCount: 15,
-    primaryLanguage: { name: "TypeScript", color: "var(--typescript)" },
-    myRole: "Author & maintainer",
-    links: [
-      {
-        label: "Blog post",
-        url: "/blog/introducing-the-devto-mcp-server/",
-      },
-    ],
-  },
-  {
-    owner: "nickytonline",
-    name: "clawspace",
-    description:
-      "Browser-based file explorer and editor for OpenClaw workspaces. Monaco editor (the same engine powering VS Code), file browsing, editing, saving, and reverting — faster than reaching for a terminal for quick workspace edits.",
-    url: "https://github.com/nickytonline/clawspace",
-    stargazerCount: 11,
-    forkCount: 0,
-    primaryLanguage: { name: "Astro", color: "#FF5D01" },
-    myRole: "Author & maintainer",
-    links: [
-      {
-        label: "Blog post",
-        url: "/blog/clawspace-a-browser-based-file-explorer-for-openclaw/",
-      },
-    ],
-  },
-];
+export const prerender = false;
 ---
 
 <Layout

--- a/src/utils/cdn-cache.ts
+++ b/src/utils/cdn-cache.ts
@@ -1,4 +1,5 @@
 export const CDN_CACHE_MAX_SECONDS = 86_400;
+export const PROJECTS_CACHE_MAX_SECONDS = 259_200;
 
 export function isUtcMidnight(date: Date): boolean {
   return (
@@ -71,5 +72,16 @@ export function setCdnCacheHeaders(
   headers.set(
     "Netlify-CDN-Cache-Control",
     `public, max-age=${maxAge}, must-revalidate`
+  );
+}
+
+export function setFixedCdnCacheHeaders(
+  headers: Headers,
+  maxAgeSeconds: number
+): void {
+  headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+  headers.set(
+    "Netlify-CDN-Cache-Control",
+    `public, max-age=${maxAgeSeconds}, must-revalidate`
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The projects page was fully static: descriptions, roles, links, and star/fork counts were all hand-maintained in `projects.astro`, so stars only changed when someone edited the file and redeployed.

This PR keeps the curated copy bespoke while fetching live GitHub stats at render time, and improves how long descriptions display on project cards.

- **Bespoke (unchanged workflow):** which repos appear, descriptions, roles, links, and language badge colors live in `src/data/curated-projects.ts`.
- **Live from GitHub:** `stargazerCount`, `forkCount`, and language name (when not overridden) are fetched via GraphQL using the existing `GITHUB_TOKEN`.
- **Refresh cadence:** `/projects` is now SSR with a 3-day Netlify CDN cache (`PROJECTS_CACHE_MAX_SECONDS = 259_200`), matching the newsletter page pattern.
- **Resilience:** if the GitHub API is unavailable, cards fall back to the last-known stats stored alongside each project.
- **Homepage:** the featured project card reuses the same curated data and live stats enrichment.
- **Descriptions:** below `lg`, stacked cards show the full description at natural height; at `lg+` in the two-column grid, descriptions stay a fixed three-line height and scroll internally to avoid layout shift.

## Notes

There is an existing unused `github-pinned-projects` live loader registered in `live.config.ts`; this PR does not wire that up because the projects page is intentionally curated rather than pinned-profile driven.

## Testing

- `vp fmt --check .`
- `vp lint .`
- `vitest run src/lib/github/enrichCuratedProjects.test.ts` (3 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05897-dd50-7f4e-85a6-f0561bb4b4a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05897-dd50-7f4e-85a6-f0561bb4b4a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a curated portfolio of projects with descriptions, links, roles, and language details.
  - Project and featured-project statistics now reflect current GitHub stars, forks, and primary languages when available.
  - Added reliable fallback statistics and improved caching for project data.
- **Accessibility**
  - Project descriptions are now fully readable in a scrollable area on large screens and include visible keyboard focus styling.
- **Bug Fixes**
  - Improved resilience when GitHub data cannot be retrieved by preserving project information and cached statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->