### PR TITLE
feat: add CYC 2026 slides to MCP app talk

### DIFF
--- a/src/content/talks/build-your-first-mcp-app-commit-your-code-2026.md
+++ b/src/content/talks/build-your-first-mcp-app-commit-your-code-2026.md
@@ -10,6 +10,7 @@ venue:
   url: "https://www.commityourcode.com/"
   location: "Capital One Campus, Plano, TX"
 registrationUrl: "https://www.commityourcode.com/"
+slideDeck: https://cyc2026.netlify.app/
 tags: ["mcp", "agentic ai", "pomerium", "zero trust", "security", "ai"]
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the [CYC 2026 slide deck](https://cyc2026.netlify.app/) to the Build your First MCP App talk page via the existing `slideDeck` frontmatter field. The talk page already renders a **View Slides** button when that field is set.

`main` is protected (PRs + required checks), so this is the path to land the change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91fa3b74-919b-470b-85f7-f7e81d0e26ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91fa3b74-919b-470b-85f7-f7e81d0e26ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a slide deck link to the “Build Your First MCP App: Commit Your Code” talk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->