### PR TITLE
feat: show calendar and live links on upcoming video pages

### DIFF
--- a/e2e/watch-and-videos.spec.ts
+++ b/e2e/watch-and-videos.spec.ts
@@ -97,7 +97,7 @@ test.describe("video archives", () => {
     }
 
     const section = upcomingHeading.locator("xpath=ancestor::section");
-    const videoLink = section.locator('a[href^="/videos/"]').first();
+    const videoLink = section.locator('a[href*="/videos/"]').first();
     if ((await videoLink.count()) === 0) {
       test.skip(true, "upcoming streams have no on-site video pages");
     }

--- a/e2e/watch-and-videos.spec.ts
+++ b/e2e/watch-and-videos.spec.ts
@@ -97,11 +97,6 @@ test.describe("video archives", () => {
     }
 
     const section = upcomingHeading.locator("xpath=ancestor::section");
-    await expect(section.getByText("Watch live on:").first()).toBeVisible();
-    await expect(
-      section.getByRole("button", { name: /Add .+ to calendar/i }).first()
-    ).toBeVisible();
-
     const videoLink = section.locator('a[href^="/videos/"]').first();
     if ((await videoLink.count()) === 0) {
       test.skip(true, "upcoming streams have no on-site video pages");

--- a/e2e/watch-and-videos.spec.ts
+++ b/e2e/watch-and-videos.spec.ts
@@ -97,9 +97,9 @@ test.describe("video archives", () => {
     }
 
     const section = upcomingHeading.locator("xpath=ancestor::section");
-    await expect(section.getByText("Watch live on:")).toBeVisible();
+    await expect(section.getByText("Watch live on:").first()).toBeVisible();
     await expect(
-      section.getByRole("button", { name: /Add .+ to calendar/i })
+      section.getByRole("button", { name: /Add .+ to calendar/i }).first()
     ).toBeVisible();
 
     const videoLink = section.locator('a[href^="/videos/"]').first();

--- a/e2e/watch-and-videos.spec.ts
+++ b/e2e/watch-and-videos.spec.ts
@@ -78,9 +78,13 @@ test.describe("video archives", () => {
 
     expect(videoStructuredDataCount).toBe(1);
     await expect(page.getByText("Upcoming livestream")).toHaveCount(0);
+    await expect(page.getByText("Watch live on:")).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /Add .+ to calendar/i })
+    ).toHaveCount(0);
   });
 
-  test("upcoming stream video pages show an upcoming pill", async ({
+  test("upcoming stream video pages show calendar and live links", async ({
     page,
   }) => {
     await page.goto("/watch");
@@ -100,5 +104,9 @@ test.describe("video archives", () => {
 
     await videoLink.click();
     await expect(page.getByText("Upcoming livestream")).toBeVisible();
+    await expect(page.getByText("Watch live on:")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Add .+ to calendar/i })
+    ).toBeVisible();
   });
 });

--- a/e2e/watch-and-videos.spec.ts
+++ b/e2e/watch-and-videos.spec.ts
@@ -97,6 +97,11 @@ test.describe("video archives", () => {
     }
 
     const section = upcomingHeading.locator("xpath=ancestor::section");
+    await expect(section.getByText("Watch live on:")).toBeVisible();
+    await expect(
+      section.getByRole("button", { name: /Add .+ to calendar/i })
+    ).toBeVisible();
+
     const videoLink = section.locator('a[href^="/videos/"]').first();
     if ((await videoLink.count()) === 0) {
       test.skip(true, "upcoming streams have no on-site video pages");

--- a/src/components/LiveStreamCard.astro
+++ b/src/components/LiveStreamCard.astro
@@ -2,7 +2,6 @@
 import { Image } from "astro:assets";
 import EventCalendar from "./EventCalendar";
 import Pill from "./Pill.astro";
-import StreamLinks from "./StreamLinks.astro";
 
 interface Platform {
   name: string;
@@ -38,10 +37,6 @@ const {
   upcoming,
   category,
 } = Astro.props;
-
-const youtubeUrl = platforms.find((p) => p.name === "YouTube")?.url;
-const twitchUrl = platforms.find((p) => p.name === "Twitch")?.url;
-const linkedinUrl = platforms.find((p) => p.name === "LinkedIn")?.url;
 ---
 
 <div class="stream-card group grid md:flex gap-3 md:gap-6 xl:gap-8">
@@ -99,15 +94,6 @@ const linkedinUrl = platforms.find((p) => p.name === "LinkedIn")?.url;
     <time class="italic text-base text-muted-foreground font-normal"
       >{datetime}</time
     >
-    {
-      upcoming && (
-        <StreamLinks
-          youtubeUrl={youtubeUrl}
-          twitchUrl={twitchUrl}
-          linkedinUrl={linkedinUrl}
-        />
-      )
-    }
     <div class="flex flex-wrap items-center gap-2 pt-1">
       {category && <Pill label={category} aria-hidden="true" />}
       {

--- a/src/components/LiveStreamCard.astro
+++ b/src/components/LiveStreamCard.astro
@@ -2,6 +2,7 @@
 import { Image } from "astro:assets";
 import EventCalendar from "./EventCalendar";
 import Pill from "./Pill.astro";
+import StreamLinks from "./StreamLinks.astro";
 
 interface Platform {
   name: string;
@@ -37,6 +38,10 @@ const {
   upcoming,
   category,
 } = Astro.props;
+
+const youtubeUrl = platforms.find((p) => p.name === "YouTube")?.url;
+const twitchUrl = platforms.find((p) => p.name === "Twitch")?.url;
+const linkedinUrl = platforms.find((p) => p.name === "LinkedIn")?.url;
 ---
 
 <div class="stream-card group grid md:flex gap-3 md:gap-6 xl:gap-8">
@@ -94,6 +99,15 @@ const {
     <time class="italic text-base text-muted-foreground font-normal"
       >{datetime}</time
     >
+    {
+      upcoming && (
+        <StreamLinks
+          youtubeUrl={youtubeUrl}
+          twitchUrl={twitchUrl}
+          linkedinUrl={linkedinUrl}
+        />
+      )
+    }
     <div class="flex flex-wrap items-center gap-2 pt-1">
       {category && <Pill label={category} aria-hidden="true" />}
       {

--- a/src/components/StreamLinks.astro
+++ b/src/components/StreamLinks.astro
@@ -6,34 +6,34 @@ interface Props {
 }
 
 const { youtubeUrl, linkedinUrl, twitchUrl } = Astro.props;
+
+const platforms = [
+  twitchUrl ? { name: "Twitch", url: twitchUrl } : null,
+  youtubeUrl ? { name: "YouTube", url: youtubeUrl } : null,
+  linkedinUrl ? { name: "LinkedIn", url: linkedinUrl } : null,
+].filter((platform): platform is { name: string; url: string } =>
+  Boolean(platform),
+);
 ---
 
-<div class="flex flex-wrap gap-2 items-center">
-  <p>Watch live on:</p>
-  {
-    (
-      <ul class="flex gap-4">
-        {twitchUrl ? (
+{
+  platforms.length > 0 && (
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-base text-muted-foreground">
+      <p>Watch live on:</p>
+      <ul class="flex flex-wrap gap-x-3 gap-y-1">
+        {platforms.map(({ name, url }) => (
           <li>
-            <a href={twitchUrl}>Twitch</a>
+            <a
+              href={url}
+              class="font-medium text-brand hover:underline focus:underline"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {name}
+            </a>
           </li>
-        ) : null}
-        {youtubeUrl ? (
-          <li>
-            <a href={youtubeUrl}>YouTube</a>
-          </li>
-        ) : null}
-        {linkedinUrl ? (
-          <li>
-            <a href={linkedinUrl}>LinkedIn</a>
-          </li>
-        ) : null}
+        ))}
       </ul>
-    )
-  }
-</div>
-<style>
-  a:not(class) {
-    text-decoration: underline;
-  }
-</style>
+    </div>
+  )
+}

--- a/src/components/StreamSchedule.astro
+++ b/src/components/StreamSchedule.astro
@@ -51,7 +51,7 @@ const fullSchedule: Array<StreamGuestInfo> = schedule.sort((a, b) => {
       const headingId = getHeadingId(guestName, date);
       const eventLocation = `${Astro.request.url}#${headingId}`;
       const videoPageUrl = youtubeStreamLink
-        ? `${new URL(Astro.request.url).origin}/videos/${slugifyVideo(title, guestName)}`
+        ? `/videos/${slugifyVideo(title, guestName)}`
         : undefined;
       const noGuest =
         guestName === "nickytonline" || guestName === "2Full2Stack";

--- a/src/content/_loaders/stream-schedule.ts
+++ b/src/content/_loaders/stream-schedule.ts
@@ -11,6 +11,24 @@ function getClient() {
   });
 }
 
+/**
+ * Returns the value only if it is a valid http(s) URL, otherwise undefined.
+ * Keeps z.url() schema fields from rejecting dirty Turso values.
+ */
+function sanitizeHttpUrl(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value) return undefined;
+  const lower = value.toLowerCase();
+  if (!lower.startsWith("http://") && !lower.startsWith("https://")) {
+    return undefined;
+  }
+  try {
+    new URL(value);
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
 function mapRowToSchedule(row: Record<string, unknown>): StreamGuestInfo {
   const {
     type,
@@ -46,7 +64,7 @@ function mapRowToSchedule(row: Record<string, unknown>): StreamGuestInfo {
     title: title as string,
     description: description as string,
     youtubeStreamLink: (youtube_stream_link as string) ?? undefined,
-    linkedinStreamLink: (linkedin_stream_link as string) ?? undefined,
+    linkedinStreamLink: sanitizeHttpUrl(linkedin_stream_link),
     twitter: (twitter as string) ?? undefined,
     twitch: (twitch as string) ?? undefined,
     github: (github as string) ?? undefined,

--- a/src/content/_loaders/stream-videos.ts
+++ b/src/content/_loaders/stream-videos.ts
@@ -8,6 +8,7 @@ export interface StreamVideoInfo extends Record<string, unknown> {
   title: string;
   description: string;
   youtubeStreamLink: string;
+  linkedinStreamLink?: string;
   guestName: string;
   guestTitle?: string;
   twitter?: string;
@@ -59,6 +60,7 @@ function mapRowToVideo(row: Record<string, unknown>): StreamVideoInfo {
     guest_name,
     guest_title,
     youtube_stream_link,
+    linkedin_stream_link,
     twitter,
     twitch,
     github,
@@ -90,6 +92,7 @@ function mapRowToVideo(row: Record<string, unknown>): StreamVideoInfo {
     title: title as string,
     description: description as string,
     youtubeStreamLink: youtube_stream_link as string,
+    linkedinStreamLink: (linkedin_stream_link as string) ?? undefined,
     twitter: (twitter as string) ?? undefined,
     twitch: (twitch as string) ?? undefined,
     github: (github as string) ?? undefined,

--- a/src/content/_loaders/stream-videos.ts
+++ b/src/content/_loaders/stream-videos.ts
@@ -92,10 +92,7 @@ function mapRowToVideo(row: Record<string, unknown>): StreamVideoInfo {
     title: title as string,
     description: description as string,
     youtubeStreamLink: youtube_stream_link as string,
-    linkedinStreamLink:
-      typeof linkedin_stream_link === "string" && linkedin_stream_link
-        ? linkedin_stream_link
-        : undefined,
+    linkedinStreamLink: sanitizeWebsiteUrl(linkedin_stream_link),
     twitter: (twitter as string) ?? undefined,
     twitch: (twitch as string) ?? undefined,
     github: (github as string) ?? undefined,

--- a/src/content/_loaders/stream-videos.ts
+++ b/src/content/_loaders/stream-videos.ts
@@ -92,7 +92,10 @@ function mapRowToVideo(row: Record<string, unknown>): StreamVideoInfo {
     title: title as string,
     description: description as string,
     youtubeStreamLink: youtube_stream_link as string,
-    linkedinStreamLink: (linkedin_stream_link as string) ?? undefined,
+    linkedinStreamLink:
+      typeof linkedin_stream_link === "string" && linkedin_stream_link
+        ? linkedin_stream_link
+        : undefined,
     twitter: (twitter as string) ?? undefined,
     twitch: (twitch as string) ?? undefined,
     github: (github as string) ?? undefined,

--- a/src/live.config.ts
+++ b/src/live.config.ts
@@ -82,7 +82,9 @@ const streamVideos = defineLiveCollection({
     guestName: z.string().min(1),
     guestTitle: z.string().optional(),
     youtubeStreamLink: z.string().min(1),
-    linkedinStreamLink: z.url().optional(),
+    // string (not z.url) so dirty Turso values cannot empty the collection;
+    // the loader already drops non-http(s) values
+    linkedinStreamLink: z.string().optional(),
     twitter: z.string().optional(),
     youtube: z.string().optional(),
     twitch: z.string().optional(),

--- a/src/live.config.ts
+++ b/src/live.config.ts
@@ -82,6 +82,7 @@ const streamVideos = defineLiveCollection({
     guestName: z.string().min(1),
     guestTitle: z.string().optional(),
     youtubeStreamLink: z.string().min(1),
+    linkedinStreamLink: z.url().optional(),
     twitter: z.string().optional(),
     youtube: z.string().optional(),
     twitch: z.string().optional(),

--- a/src/pages/videos/[slug].astro
+++ b/src/pages/videos/[slug].astro
@@ -7,23 +7,59 @@ import { site } from "../../data/site";
 import { markdownFilter } from "../../utils/markdown";
 import YouTubeEmbed from "../../components/embeds/YouTubeEmbed.astro";
 import UpcomingBadge from "../../components/UpcomingBadge.astro";
+import EventCalendar from "../../components/EventCalendar";
+import StreamLinks from "../../components/StreamLinks.astro";
 import {
   extractYouTubeVideoId,
   slugifyVideo,
 } from "../../utils/video-utils";
+import {
+  eventExpiryTimestamp,
+  isEventUpcoming,
+  setCdnCacheHeaders,
+} from "../../utils/cdn-cache";
 
-export async function getStaticPaths() {
-  const result = await getLiveCollection("streamVideos");
-  return (result.entries ?? []).map((stream) => ({
-    params: { slug: slugifyVideo(stream.data.title, stream.data.guestName) },
-    props: { stream },
-  }));
+export const prerender = false;
+
+const TWITCH_STREAM_URL = "https://www.twitch.tv/nickytonline";
+
+const { slug } = Astro.params;
+
+if (!slug) {
+  throw new Error("Video not found");
 }
 
-const { stream } = Astro.props;
-const { title, date, description, guestName, guestTitle, youtubeStreamLink } =
-  stream.data;
-const isUpcoming = new Date(date).getTime() > Date.now();
+const result = await getLiveCollection("streamVideos");
+
+if (result.error) {
+  throw result.error;
+}
+
+const stream = (result.entries ?? []).find(
+  (entry) => slugifyVideo(entry.data.title, entry.data.guestName) === slug,
+);
+
+if (!stream) {
+  throw new Error("Video not found");
+}
+
+const {
+  title,
+  date,
+  description,
+  guestName,
+  guestTitle,
+  youtubeStreamLink,
+  linkedinStreamLink,
+  type,
+} = stream.data;
+const now = Date.now();
+const isUpcoming = isEventUpcoming(new Date(date), now);
+setCdnCacheHeaders(
+  Astro.response.headers,
+  isUpcoming ? eventExpiryTimestamp(new Date(date)) : undefined,
+  now,
+);
 const descriptionHtml = markdownFilter(description);
 
 const videoId = extractYouTubeVideoId(youtubeStreamLink);
@@ -31,6 +67,11 @@ const socialImage = videoId
   ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
   : "/assets/images/page-og/watch.jpg";
 const pageUrl = new URL(Astro.url.pathname, site.url).toString();
+const eventName =
+  guestName === "2Full2Stack"
+    ? `2 Full 2 Stack - ${title}`
+    : `${type === "pomerium-live" ? "Pomerium Live Stream" : "nickyt.live"}: ${title}`;
+const twitchStreamUrl = type === "nickyt.live" ? TWITCH_STREAM_URL : undefined;
 const videoJsonLd = {
   "@context": "https://schema.org",
   "@type": "VideoObject",
@@ -158,6 +199,25 @@ if (stream.data.website)
         with <span class="font-semibold">{guestName}</span>
         {guestTitle && <span> — {guestTitle}</span>}
       </p>
+      {
+        isUpcoming && (
+          <div class="mt-4 flex flex-col gap-3">
+            <StreamLinks
+              youtubeUrl={youtubeStreamLink}
+              twitchUrl={twitchStreamUrl}
+              linkedinUrl={linkedinStreamLink}
+            />
+            <EventCalendar
+              eventDate={date}
+              eventName={eventName}
+              description={description}
+              duration={90}
+              location={youtubeStreamLink}
+              client:visible
+            />
+          </div>
+        )
+      }
     </header>
 
     {
@@ -175,16 +235,13 @@ if (stream.data.website)
             href={youtubeStreamLink}
             class="text-brand hover:underline focus:underline"
           >
-          Watch on YouTube
+            Watch on YouTube
           </a>
         </div>
       )
     }
 
-    <div
-      class="prose max-w-none"
-      set:html={descriptionHtml}
-    />
+    <div class="prose max-w-none" set:html={descriptionHtml} />
 
     {
       socials.length > 0 && (

--- a/src/pages/videos/[slug].astro
+++ b/src/pages/videos/[slug].astro
@@ -26,13 +26,14 @@ const TWITCH_STREAM_URL = "https://www.twitch.tv/nickytonline";
 const { slug } = Astro.params;
 
 if (!slug) {
-  throw new Error("Video not found");
+  return Astro.rewrite("/404");
 }
 
 const result = await getLiveCollection("streamVideos");
 
 if (result.error) {
-  throw result.error;
+  console.error("Error loading stream videos:", result.error);
+  return Astro.rewrite("/404");
 }
 
 const stream = (result.entries ?? []).find(
@@ -40,7 +41,7 @@ const stream = (result.entries ?? []).find(
 );
 
 if (!stream) {
-  throw new Error("Video not found");
+  return Astro.rewrite("/404");
 }
 
 const {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Upcoming stream video pages (e.g. [Commit Your Code recap](https://www.nickyt.co/videos/commit-your-code-cyc-recap-and-communities-roxy-rodriguez-becker/)) already showed the upcoming pill, but not the Add to Calendar control or live platform links that livestream cards use.

## Changes
- Upcoming `/videos/[slug]` pages show **Add to Calendar** plus **Watch live on** Twitch (`nickyt.live`), YouTube, and LinkedIn when a LinkedIn stream URL exists
- Past video pages omit those controls (guest profile Links section is unchanged)
- Video detail pages are SSR with CDN cache expiry at the stream date so upcoming UI drops off after the event
- Homepage/watch upcoming livestream cards also show **Watch live on** again alongside Add to Calendar
- `streamVideos` loader/schema include `linkedinStreamLink`, with invalid Turso values sanitized so collection load does not fail
- Upcoming e2e checks run only when an upcoming stream video page exists

## Test plan
- On `/` or `/watch`, confirm an upcoming stream card shows Watch live on + Add to Calendar
- Open that stream's video page and confirm the same controls appear under the upcoming pill
- Confirm `/videos` lists archives again (not empty)
- Confirm past videos do not show calendar or Watch live on
- Confirm guest social Links still appear on past and upcoming pages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07366-ec9f-7d94-a89b-f1f159dce82c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07366-ec9f-7d94-a89b-f1f159dce82c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upcoming livestreams now display “Watch live on” links for available platforms, including YouTube, Twitch, and LinkedIn.
  * Upcoming video pages include streaming links and an option to add the event to a calendar.
  * Video pages now support LinkedIn stream information and Twitch links for eligible streams.

* **Bug Fixes**
  * Past video pages no longer display livestream links or calendar-add buttons.
  * Invalid streaming URLs are now excluded from displayed links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->