### PR TITLE
fix: Add to Calendar opens on first click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,8 @@
       "devDependencies": {
         "@playwright/test": "^1.61.1",
         "@tailwindcss/vite": "^4.3.3",
+        "@testing-library/react": "^16.3.3",
+        "@testing-library/user-event": "^14.6.7",
         "@types/js-yaml": "^4.0.9",
         "@types/jsdom": "^28.0.1",
         "@types/luxon": "^3.7.4",
@@ -7060,10 +7062,38 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@testing-library/user-event": {
-      "version": "14.6.6",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
-      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "@tailwindcss/vite": "^4.3.3",
+    "@testing-library/react": "^16.3.3",
+    "@testing-library/user-event": "^14.6.7",
     "@types/js-yaml": "^4.0.9",
     "@types/jsdom": "^28.0.1",
     "@types/luxon": "^3.7.4",

--- a/src/components/EventCalendar.test.tsx
+++ b/src/components/EventCalendar.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import EventCalendar from "./EventCalendar.tsx";
+
+describe("EventCalendar", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function renderCalendar() {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        <EventCalendar
+          eventName="Test Stream"
+          eventDate="2026-09-09T14:00:00.000Z"
+          duration={60}
+          description="A test stream"
+          location="https://nickyt.co"
+        />
+      );
+    });
+  }
+
+  it("opens the menu on the first click after focus", () => {
+    renderCalendar();
+
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => {
+      button?.focus();
+      button?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(button?.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+  });
+
+  it("keeps the menu open when clicking while already focused", () => {
+    renderCalendar();
+
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+
+    act(() => {
+      button?.focus();
+    });
+    expect(button?.getAttribute("aria-expanded")).toBe("true");
+
+    act(() => {
+      button?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(button?.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+  });
+});

--- a/src/components/EventCalendar.test.tsx
+++ b/src/components/EventCalendar.test.tsx
@@ -1,75 +1,82 @@
 /**
  * @vitest-environment jsdom
  */
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
-import { createRoot, type Root } from "react-dom/client";
-import { act } from "react";
 import EventCalendar from "./EventCalendar.tsx";
 
+const props = {
+  eventName: "Test Stream",
+  eventDate: "2026-09-09T14:00:00.000Z",
+  duration: 60,
+  description: "A test stream",
+  location: "https://nickyt.co",
+} as const;
+
+afterEach(() => {
+  cleanup();
+});
+
 describe("EventCalendar", () => {
-  let container: HTMLDivElement;
-  let root: Root;
+  it("opens the calendar menu on the first click after focus (#1104)", async () => {
+    const user = userEvent.setup();
+    render(<EventCalendar {...props} />);
 
-  afterEach(() => {
-    act(() => {
-      root.unmount();
+    const button = screen.getByRole("button", {
+      name: "Add Test Stream to calendar",
     });
-    container.remove();
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    // userEvent focuses then clicks — the regression was focus opening
+    // the menu and click toggling it closed on that same interaction.
+    await user.click(button);
+
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    const menu = screen.getByRole("menu");
+    expect(
+      within(menu).getByRole("menuitem", { name: /google calendar/i })
+    ).toBeTruthy();
+    expect(
+      within(menu).getByRole("menuitem", { name: /outlook calendar/i })
+    ).toBeTruthy();
+    expect(
+      within(menu).getByRole("menuitem", { name: /ical\/apple calendar/i })
+    ).toBeTruthy();
   });
 
-  function renderCalendar() {
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
-    act(() => {
-      root.render(
-        <EventCalendar
-          eventName="Test Stream"
-          eventDate="2026-09-09T14:00:00.000Z"
-          duration={60}
-          description="A test stream"
-          location="https://nickyt.co"
-        />
-      );
-    });
-  }
+  it("keeps the menu open when clicking an already focused button", async () => {
+    const user = userEvent.setup();
+    render(<EventCalendar {...props} />);
 
-  it("opens the menu on the first click after focus", () => {
-    renderCalendar();
-
-    const button = container.querySelector("button");
-    expect(button).not.toBeNull();
-    expect(button?.getAttribute("aria-expanded")).toBe("false");
-
-    act(() => {
-      button?.focus();
-      button?.dispatchEvent(
-        new MouseEvent("click", { bubbles: true, cancelable: true })
-      );
+    const button = screen.getByRole("button", {
+      name: "Add Test Stream to calendar",
     });
 
-    expect(button?.getAttribute("aria-expanded")).toBe("true");
-    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+    await user.tab();
+    expect(document.activeElement).toBe(button);
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("menu")).toBeTruthy();
+
+    await user.click(button);
+
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("menu")).toBeTruthy();
   });
 
-  it("keeps the menu open when clicking while already focused", () => {
-    renderCalendar();
+  it("opens the menu from keyboard activation", async () => {
+    const user = userEvent.setup();
+    render(<EventCalendar {...props} />);
 
-    const button = container.querySelector("button");
-    expect(button).not.toBeNull();
-
-    act(() => {
-      button?.focus();
-    });
-    expect(button?.getAttribute("aria-expanded")).toBe("true");
-
-    act(() => {
-      button?.dispatchEvent(
-        new MouseEvent("click", { bubbles: true, cancelable: true })
-      );
+    const button = screen.getByRole("button", {
+      name: "Add Test Stream to calendar",
     });
 
-    expect(button?.getAttribute("aria-expanded")).toBe("true");
-    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+    await user.tab();
+    await user.keyboard("{Enter}");
+
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("menu")).toBeTruthy();
   });
 });

--- a/src/components/EventCalendar.tsx
+++ b/src/components/EventCalendar.tsx
@@ -28,15 +28,15 @@ const EventCalendar = ({
   const startDate = new Date(eventDate);
   const endDate = new Date(startDate.getTime() + durationInMillis);
   const menuId = `calendar-menu-${eventName.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
-  const toggleMenu = () => setIsExpanded((current) => !current);
+  const openMenu = () => setIsExpanded(true);
   const closeMenu = () => setIsExpanded(false);
 
   return (
     <div
       className="relative flex w-fit items-center"
-      onMouseEnter={() => setIsExpanded(true)}
-      onMouseLeave={() => setIsExpanded(false)}
-      onFocusCapture={() => setIsExpanded(true)}
+      onMouseEnter={openMenu}
+      onMouseLeave={closeMenu}
+      onFocusCapture={openMenu}
       onBlurCapture={(event) => {
         const nextFocusTarget = event.relatedTarget as Node | null;
         if (!event.currentTarget.contains(nextFocusTarget)) {
@@ -50,7 +50,8 @@ const EventCalendar = ({
         aria-haspopup="menu"
         aria-controls={menuId}
         aria-label={`Add ${eventName} to calendar`}
-        onClick={toggleMenu}
+        // Open only — toggle fights focus/hover open on the same click (#1104).
+        onClick={openMenu}
         className="inline-flex items-center gap-1.5 rounded-md border border-brand/30 bg-brand-soft px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-brand-soft-foreground hover:bg-background hover:text-brand focus-visible:bg-background focus-visible:text-brand focus-visible:border-brand transition-colors"
       >
         <Plus className="w-3 h-3" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1104.

## Problem

The homepage **Add to Calendar** control needed two mouse clicks to open. Keyboard Enter/Space already worked on the first press.

Root cause: `onFocusCapture` / `onMouseEnter` open the menu, then `onClick` toggled it closed on the same interaction.

## Fix

Change the button click handler from toggle → open (`setIsExpanded(true)`). Hover, focus, blur, and mouseleave still manage open/close as before.

## Tests

Component tests in `src/components/EventCalendar.test.tsx` (Testing Library + user-event):

- First click after focus opens the menu (#1104 regression)
- Click while already focused keeps the menu open
- Keyboard Enter opens the menu

## Test plan

- [x] `vp test run src/components/EventCalendar.test.tsx`
- [x] Local harness: single click opens menu; keyboard still opens
- [ ] On `/`, click **Add to Calendar** once — menu should open
- [ ] Hover still opens; leaving closes
- [ ] Tab to the button, then Enter/Space — menu opens
- [ ] Tab away / blur — menu closes
- [ ] Calendar links (Google / Outlook / iCal) still work

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0738b-57db-73cc-a20d-5ef9daa8fee3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0738b-57db-73cc-a20d-5ef9daa8fee3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

