### PR TITLE
ci: run Vitest unit/component tests on PRs

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,0 +1,23 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  vitest:
+    name: Vitest unit/component tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 24
+          cache: true
+
+      - name: Run Vitest
+        run: vp test run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,16 @@
 - Required vars for the site: `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`, `TURSO_SEARCH_DATABASE_URL`, `TURSO_SEARCH_AUTH_TOKEN`, `GITHUB_TOKEN`, `DEV_API_KEY`, `GEMINI_API_KEY`, `URL`.
 - Sync scripts use scoped Varlock env dirs instead of the root schema: `env/devto/.env.schema` (imports `DEV_API_KEY`, used by `vp run generate:posts`) and `env/search/.env.schema` (`GEMINI_API_KEY`, `TURSO_SEARCH_*`, optional `TURSO_*` for stream guests, used by `vp run index:search`). All are invoked as `varlock run --path env/<name> -- ...` from `package.json`. Live streams and schedule come from Turso via Astro live loaders (`streamVideos`, `streamSchedule`). Embeddings run in `.github/workflows/index-search.yml` on **push to `main`**, **workflow_dispatch**, and when production SSR pages (`/`, `/watch`, `/newsletter`) regenerate after CDN cache expiry. Those Netlify functions detect production from `Astro.locals.netlify.context.deploy.context` (not `process.env.CONTEXT`, which is outside the Varlock schema and unset in the SSR bundle), dispatch the workflow with `GITHUB_TOKEN` (`actions:write`) at most once per hour, and log `[search-reindex] Kicked off…` or a skip reason when they run. Not during the Netlify build and not on PRs. Batches of 5 with a 5s pause so Gemini rate limits are tolerated; content hashes skip unchanged docs.
 
-## Testing (E2E)
+## Testing
+
+### Unit / component (Vitest)
+
+- Colocated under `src/` as `*.test.ts` / `*.test.tsx` (configured in `vite.config.ts` `test.include`).
+- Run with `vp test` / `vp test run` (or `vp run test`).
+- Prefer Vitest + Testing Library for interactive React behavior (focus, clicks, keyboard). Skip for static Astro markup.
+- CI: `.github/workflows/vitest.yml` runs `vp test run` on pull requests (no app secrets).
+
+### E2E (Playwright)
 
 - Playwright specs live in `e2e/`; run with `vp run test:e2e` (`test:e2e:ui` for UI mode, `test:e2e:report` to reopen the last HTML report).
 - Locally, tests run against a real production build, not the dev server: `playwright.config.ts`'s `webServer` builds and serves via `npx varlock run -- netlify serve` unless `PLAYWRIGHT_BASE_URL` is set. This is required, not optional — `astro preview` throws ("adapter does not support the preview command") because `@astrojs/netlify` has no preview entrypoint, and search hits the production `/api/search` function against the Turso index.

--- a/contributing.md
+++ b/contributing.md
@@ -9,7 +9,10 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a
    build.
-2. Ensure your work is thoroughly tested, to the best of your abilities
+2. Ensure your work is thoroughly tested, to the best of your abilities.
+   Unit/component tests (`vp test run`, Vitest under `src/`) run in CI on PRs.
+   Interactive React changes should include a colocated `*.test.tsx` when behavior
+   can regress. E2E coverage lives under `e2e/` (`vp run test:e2e`).
 3. You may merge the Pull Request in once you have the sign-off from a maintainer
 
 ## Code of Conduct

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "vp lint --fix .",
     "generate:posts": "varlock run --path env/devto -- node ./bin/generateDevToPosts.ts",
     "index:search": "varlock run --path env/search -- node ./bin/indexSearch.ts",
+    "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  test: {
+    // Keep Playwright specs out of `vp test` — they live under e2e/ and
+    // need a deployed/served site, not Vitest's jsdom runner.
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
   lint: {
     plugins: ["oxc", "typescript", "unicorn", "react", "jsx-a11y"],
     jsPlugins: ["eslint-plugin-astro"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1106.

## Problem

Vitest tests under `src/` (including `EventCalendar.test.tsx`) never ran in CI — only Playwright e2e did — so unit/component regressions would not fail PRs.

## Changes

- Add `.github/workflows/vitest.yml` — `vp test run` on `pull_request` / `workflow_dispatch`
- Scope Vitest to `src/**/*.{test,spec}.{ts,tsx}` so Playwright specs under `e2e/` are not picked up
- Add `npm test` → `vitest run`
- Document unit/component testing in `AGENTS.md` and `contributing.md`

## Test plan

- [x] `vp test run` — 6 files / 41 tests pass locally
- [ ] CI Vitest check is green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0738b-57db-73cc-a20d-5ef9daa8fee3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0738b-57db-73cc-a20d-5ef9daa8fee3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

