### PR TITLE
fix: use fixed 2-day CDN cache for schedule pages

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,8 +22,8 @@ import {
 import {
   isEventUpcoming,
   isTalkUpcoming,
-  setCdnCacheHeaders,
-  soonestExpiryTimestamp,
+  SCHEDULE_CDN_CACHE_SECONDS,
+  setFixedCdnCacheHeaders,
 } from "../utils/cdn-cache";
 import { scheduleSearchReindex } from "../lib/search/scheduleSearchReindex";
 
@@ -155,17 +155,9 @@ const { timezone: rawTimezone } = Astro.locals.netlify.context.geo;
 const timezone = rawTimezone || "UTC";
 
 if (!errorMessage) {
-  setCdnCacheHeaders(
+  setFixedCdnCacheHeaders(
     Astro.response.headers,
-    soonestExpiryTimestamp(
-      upcomingEvents.map((event) =>
-        event.kind === "talk"
-          ? (event.item.data.endDate ?? event.item.data.date)
-          : new Date(event.item.date),
-      ),
-      now.getTime(),
-    ),
-    now.getTime(),
+    SCHEDULE_CDN_CACHE_SECONDS,
   );
   Astro.response.headers.set("timezone", timezone);
   Astro.response.headers.set("Netlify-Vary", "header=Accept-Language|timezone");

--- a/src/pages/watch.astro
+++ b/src/pages/watch.astro
@@ -11,8 +11,8 @@ import { getYouTubeId } from "@/utils/youtube-utils";
 import { slugifyVideo } from "@/utils/video-utils";
 import {
   isEventUpcoming,
-  setCdnCacheHeaders,
-  soonestExpiryTimestamp,
+  SCHEDULE_CDN_CACHE_SECONDS,
+  setFixedCdnCacheHeaders,
 } from "@/utils/cdn-cache";
 import { scheduleSearchReindex } from "@/lib/search/scheduleSearchReindex";
 
@@ -70,13 +70,9 @@ const { timezone: rawTimezone } = Astro.locals.netlify.context.geo;
 const timezone = rawTimezone || "UTC";
 
 if (!errorMessage) {
-  setCdnCacheHeaders(
+  setFixedCdnCacheHeaders(
     Astro.response.headers,
-    soonestExpiryTimestamp(
-      schedule.map((stream) => new Date(stream.date)),
-      now,
-    ),
-    now,
+    SCHEDULE_CDN_CACHE_SECONDS,
   );
 }
 Astro.response.headers.set("timezone", timezone);

--- a/src/utils/cdn-cache.test.ts
+++ b/src/utils/cdn-cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CDN_CACHE_MAX_SECONDS,
+  SCHEDULE_CDN_CACHE_SECONDS,
   cdnMaxAgeSeconds,
   eventExpiryTimestamp,
   isEventUpcoming,
@@ -105,5 +106,11 @@ describe("soonestExpiryTimestamp", () => {
         now
       )
     ).toBe(Date.parse("2026-01-01T01:00:00.000Z"));
+  });
+});
+
+describe("SCHEDULE_CDN_CACHE_SECONDS", () => {
+  it("is a fixed two-day TTL for schedule pages", () => {
+    expect(SCHEDULE_CDN_CACHE_SECONDS).toBe(172_800);
   });
 });

--- a/src/utils/cdn-cache.ts
+++ b/src/utils/cdn-cache.ts
@@ -1,4 +1,6 @@
 export const CDN_CACHE_MAX_SECONDS = 86_400;
+/** Fixed CDN TTL for Turso-backed schedule pages (/ and /watch). */
+export const SCHEDULE_CDN_CACHE_SECONDS = 172_800;
 export const PROJECTS_CACHE_MAX_SECONDS = 259_200;
 
 export function isUtcMidnight(date: Date): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`/` and `/watch` were CDN-caching until the next upcoming event (capped at one day). That meant a newly added stream could stay invisible until that first go-live time refreshed the edge.

These pages now use a fixed **2-day** CDN TTL (`SCHEDULE_CDN_CACHE_SECONDS`) via `setFixedCdnCacheHeaders`, so schedule updates show up within a couple of days regardless of when the next stream starts.

Talks / speaking / video archive pages still expire at the next upcoming event so “Upcoming” pills and archive membership stay timely.

## Test plan

- [x] `vp test run src/utils/cdn-cache.test.ts`
- [ ] After deploy, confirm `/watch` sends `Netlify-CDN-Cache-Control: public, max-age=172800, must-revalidate`
- [ ] Add a stream in Turso and confirm it appears on `/watch` within the 2-day window (not tied to the next live date)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07d8a-3d59-7262-89a1-03b6dd624546?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07d8a-3d59-7262-89a1-03b6dd624546&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Schedule pages now use a consistent two-day CDN cache duration.
  - Cache expiration no longer varies based on upcoming event times.
- **Tests**
  - Added coverage to verify the configured cache duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->