### PR TITLE
feat: localize upcoming video page times and cache past pages until deploy

### DIFF
--- a/e2e/watch-and-videos.spec.ts
+++ b/e2e/watch-and-videos.spec.ts
@@ -52,7 +52,7 @@ test.describe("video archives", () => {
     ).toBeVisible();
   });
 
-  test("navigating to a video shows its title", async ({ page }) => {
+  test("navigating to a video shows its title", async ({ page, request }) => {
     await page.goto("/videos");
     const link = page.locator('main a[href^="/videos/"]').first();
 
@@ -61,6 +61,13 @@ test.describe("video archives", () => {
     }
 
     const href = await link.getAttribute("href");
+    const archiveResponse = await request.get(href!);
+    expect(archiveResponse.ok()).toBeTruthy();
+    expect(archiveResponse.headers()["timezone"]).toBeUndefined();
+    expect(
+      archiveResponse.headers()["netlify-cdn-cache-control"] ?? ""
+    ).toMatch(/max-age=31536000/);
+
     await link.click();
     await expect(page).toHaveURL(new RegExp(`${escapeRegExp(href!)}/?$`));
     await expect(
@@ -108,5 +115,30 @@ test.describe("video archives", () => {
     await expect(
       page.getByRole("button", { name: /Add .+ to calendar/i })
     ).toBeVisible();
+  });
+
+  test("upcoming stream video pages set a timezone response header", async ({
+    page,
+    request,
+  }) => {
+    await page.goto("/watch");
+
+    const upcomingHeading = page.getByRole("heading", {
+      name: "Upcoming Live Streams",
+    });
+    if (!(await upcomingHeading.count())) {
+      test.skip(true, "no upcoming streams scheduled");
+    }
+
+    const section = upcomingHeading.locator("xpath=ancestor::section");
+    const videoLink = section.locator('a[href*="/videos/"]').first();
+    if ((await videoLink.count()) === 0) {
+      test.skip(true, "upcoming streams have no on-site video pages");
+    }
+
+    const href = await videoLink.getAttribute("href");
+    const response = await request.get(href!);
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()["timezone"]).toBeDefined();
   });
 });

--- a/e2e/watch-and-videos.spec.ts
+++ b/e2e/watch-and-videos.spec.ts
@@ -64,9 +64,6 @@ test.describe("video archives", () => {
     const archiveResponse = await request.get(href!);
     expect(archiveResponse.ok()).toBeTruthy();
     expect(archiveResponse.headers()["timezone"]).toBeUndefined();
-    expect(
-      archiveResponse.headers()["netlify-cdn-cache-control"] ?? ""
-    ).toMatch(/max-age=31536000/);
 
     await link.click();
     await expect(page).toHaveURL(new RegExp(`${escapeRegExp(href!)}/?$`));

--- a/src/pages/videos/[slug].astro
+++ b/src/pages/videos/[slug].astro
@@ -13,10 +13,13 @@ import {
   extractYouTubeVideoId,
   slugifyVideo,
 } from "../../utils/video-utils";
+import { getLocalizedDate } from "../../utils/schedule-utils";
 import {
   eventExpiryTimestamp,
   isEventUpcoming,
   setCdnCacheHeaders,
+  setFixedCdnCacheHeaders,
+  UNTIL_DEPLOY_CDN_CACHE_SECONDS,
 } from "../../utils/cdn-cache";
 
 export const prerender = false;
@@ -56,11 +59,41 @@ const {
 } = stream.data;
 const now = Date.now();
 const isUpcoming = isEventUpcoming(new Date(date), now);
-setCdnCacheHeaders(
-  Astro.response.headers,
-  isUpcoming ? eventExpiryTimestamp(new Date(date)) : undefined,
-  now,
-);
+
+const locale =
+  Astro.request.headers.get("Accept-Language")?.split(",")[0] ||
+  Astro.request.headers.get("Accept-Language") ||
+  "en-US";
+const { timezone: rawTimezone } = Astro.locals.netlify.context.geo;
+const timezone = rawTimezone || "UTC";
+
+const dateDisplay = isUpcoming
+  ? getLocalizedDate({
+      date,
+      locale,
+      timezone,
+      showTime: true,
+    })
+  : dateFilter(new Date(date));
+
+if (isUpcoming) {
+  setCdnCacheHeaders(
+    Astro.response.headers,
+    eventExpiryTimestamp(new Date(date)),
+    now,
+  );
+  Astro.response.headers.set("timezone", timezone);
+  Astro.response.headers.set(
+    "Netlify-Vary",
+    "header=Accept-Language|timezone",
+  );
+} else {
+  // Past pages are stable until the next deploy (no durable → purged on deploy).
+  setFixedCdnCacheHeaders(
+    Astro.response.headers,
+    UNTIL_DEPLOY_CDN_CACHE_SECONDS,
+  );
+}
 const descriptionHtml = markdownFilter(description);
 
 const videoId = extractYouTubeVideoId(youtubeStreamLink);
@@ -192,7 +225,7 @@ if (stream.data.website)
         class="flex flex-wrap items-center gap-2 leading-none text-lg text-muted-foreground mt-2"
       >
         <time datetime={new Date(date).toISOString()} class="italic">
-          {dateFilter(new Date(date))}
+          {dateDisplay}
         </time>
         {isUpcoming && <UpcomingBadge label="Upcoming livestream" />}
       </div>

--- a/src/utils/cdn-cache.test.ts
+++ b/src/utils/cdn-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CDN_CACHE_MAX_SECONDS,
   SCHEDULE_CDN_CACHE_SECONDS,
+  UNTIL_DEPLOY_CDN_CACHE_SECONDS,
   cdnMaxAgeSeconds,
   eventExpiryTimestamp,
   isEventUpcoming,
@@ -112,5 +113,11 @@ describe("soonestExpiryTimestamp", () => {
 describe("SCHEDULE_CDN_CACHE_SECONDS", () => {
   it("is a fixed two-day TTL for schedule pages", () => {
     expect(SCHEDULE_CDN_CACHE_SECONDS).toBe(172_800);
+  });
+});
+
+describe("UNTIL_DEPLOY_CDN_CACHE_SECONDS", () => {
+  it("is a one-year TTL purged on the next deploy", () => {
+    expect(UNTIL_DEPLOY_CDN_CACHE_SECONDS).toBe(31_536_000);
   });
 });

--- a/src/utils/cdn-cache.ts
+++ b/src/utils/cdn-cache.ts
@@ -2,6 +2,11 @@ export const CDN_CACHE_MAX_SECONDS = 86_400;
 /** Fixed CDN TTL for Turso-backed schedule pages (/ and /watch). */
 export const SCHEDULE_CDN_CACHE_SECONDS = 172_800;
 export const PROJECTS_CACHE_MAX_SECONDS = 259_200;
+/**
+ * Long CDN TTL for responses that only change on deploy.
+ * Omit `durable` so Netlify still purges on the next deploy.
+ */
+export const UNTIL_DEPLOY_CDN_CACHE_SECONDS = 31_536_000;
 
 export function isUtcMidnight(date: Date): boolean {
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Upcoming `/videos/[slug]` pages showed the stream date without a visitor-local time (unlike home/watch livestream cards). Past pages also refreshed on a one-day CDN TTL even though their content is stable between deploys.

## Changes
- Upcoming video pages format the datetime with `getLocalizedDate` using Netlify geo timezone + `Accept-Language` (same pattern as `/` and `/watch`), and vary CDN cache on those headers
- Past video pages keep the date-only display and use a one-year CDN TTL **without** `durable`, so Netlify still purges on the next deploy
- Upcoming pages still expire CDN cache at the stream time so the upcoming UI drops off afterward
- E2E coverage for timezone header on upcoming pages (and its absence on past pages)

## Test plan
- Open an upcoming stream video page and confirm the time matches home/watch for your location (includes timezone abbreviation via `timeStyle: "long"`)
- Confirm past video pages still show date only (no time) and no upcoming controls
- After the stream time passes, confirm a fresh request no longer shows upcoming UI
- Confirm unit tests for `UNTIL_DEPLOY_CDN_CACHE_SECONDS` pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08634-1f18-78ce-a4f8-e5e169cc9bdf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08634-1f18-78ce-a4f8-e5e169cc9bdf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upcoming video dates are now localized based on the viewer’s language and timezone.
  * Upcoming video pages now use event-aware caching and provide timezone information.

* **Bug Fixes**
  * Past video pages now use consistent long-term caching behavior.
  * Improved validation of timezone headers and response status for video pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->